### PR TITLE
Enable use on ~4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/http": "~4.3",
-        "illuminate/support": "~4.3",
+        "illuminate/http": "~4.1",
+        "illuminate/support": "~4.1",
         "guzzlehttp/guzzle": "~4.0",
         "league/oauth1-client": "~1.0"
     },


### PR DESCRIPTION
Missing method `getSession()` on the Request class in 4.0. http://d.enge.me/WuSl

Signed-off-by: Adam Engebretson adam@enge.me
