### PR TITLE
Revert the branch alias change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "1.0-dev"
         }
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
Since changing the version constraint from 4.3 to 5.0 is technically just a bug fix since 4.3 doesn't exist anymore. I don't see why we need a 2.0 release?
