### PR TITLE
Include API version in auth url

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -30,7 +30,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface {
 	 */
 	protected function getAuthUrl($state)
 	{
-		return $this->buildAuthUrlFromBase('https://www.facebook.com/dialog/oauth', $state);
+		return $this->buildAuthUrlFromBase('https://www.facebook.com/'. $this->version .'/dialog/oauth', $state);
 	}
 
 	/**


### PR DESCRIPTION
Prevents 1.0 upgrade warning. Reference: https://developers.facebook.com/docs/apps/versions#dialogs