### PR TITLE
Make formatConfig public

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -101,7 +101,7 @@ class SocialiteManager extends Manager implements Contracts\Factory {
 	 * @param  array  $config
 	 * @return array
 	 */
-	protected function formatConfig(array $config)
+	public function formatConfig(array $config)
 	{
 		return [
 			'identifier' => $config['client_id'],
@@ -114,7 +114,7 @@ class SocialiteManager extends Manager implements Contracts\Factory {
 	 * Get the default driver name.
 	 *
 	 * @throws \InvalidArgumentException
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getDefaultDriver()


### PR DESCRIPTION
While creating some OAuth1 Providers I needed to call formatConfig which was not possible due to the fact that it was set to protected. It should be set to public so that it could be called when a new OAuth1 Provider extends Socialite.

This doesn't work at the moment, when formatConfig is set to public everything works great.

```php
public function boot()
{
    $socialite = app()->make('Laravel\Socialite\Contracts\Factory');

    $socialite->extend('flickr', function ($app) use ($socialite) {
        $config = $app['config']['services.flickr'];

        return new FlickrProvider(
            $app['request'],
            new FlickrServer($socialite->formatConfig($config))
        );
    });
}
```