### PR TITLE
Move auth url parameters to own method in AbstractProvider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "3.0-dev"
         }
     },
     "minimum-stability": "dev"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "2.0-dev"
         }
     },
     "minimum-stability": "dev"

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -121,7 +121,7 @@ abstract class AbstractProvider implements ProviderContract {
 	{
 		$session = $this->request->getSession();
 
-        return $url.'?'.http_build_query($this->getCodeRequestParameters($state), '', '&', $this->encodingType);
+		return $url.'?'.http_build_query($this->getCodeRequestParameters($state), '', '&', $this->encodingType);
 	}
 
 	/**
@@ -181,20 +181,20 @@ abstract class AbstractProvider implements ProviderContract {
 		return $this->parseAccessToken($response->getBody());
 	}
 
-    /**
-     * Get the GET parameters for the auth_code request.
-     *
-     * @param  string  $state
-     * @return array
-     */
-    protected function getCodeRequestParameters($state)
-    {
-        return [
-            'client_id' => $this->clientId, 'redirect_uri' => $this->redirectUrl,
-            'scope' => $this->formatScopes($this->scopes, $this->scopeSeparator), 'state' => $state,
-            'response_type' => 'code',
-        ];
-    }
+	/**
+	 * Get the GET parameters for the auth_code request.
+	 *
+	 * @param  string  $state
+	 * @return array
+	 */
+	protected function getCodeRequestParameters($state)
+	{
+		return [
+			'client_id' => $this->clientId, 'redirect_uri' => $this->redirectUrl,
+			'scope' => $this->formatScopes($this->scopes, $this->scopeSeparator), 'state' => $state,
+			'response_type' => 'code',
+		];
+	}
 
 	/**
 	 * Get the POST fields for the token request.

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -121,11 +121,7 @@ abstract class AbstractProvider implements ProviderContract {
 	{
 		$session = $this->request->getSession();
 
-		return $url.'?'.http_build_query([
-			'client_id' => $this->clientId, 'redirect_uri' => $this->redirectUrl,
-			'scope' => $this->formatScopes($this->scopes, $this->scopeSeparator), 'state' => $state,
-			'response_type' => 'code',
-		], '', '&', $this->encodingType );
+        return $url.'?'.http_build_query($this->getCodeRequestParameters($state), '', '&', $this->encodingType);
 	}
 
 	/**
@@ -184,6 +180,21 @@ abstract class AbstractProvider implements ProviderContract {
 
 		return $this->parseAccessToken($response->getBody());
 	}
+
+    /**
+     * Get the GET parameters for the auth_code request.
+     *
+     * @param  string  $state
+     * @return array
+     */
+    protected function getCodeRequestParameters($state)
+    {
+        return [
+            'client_id' => $this->clientId, 'redirect_uri' => $this->redirectUrl,
+            'scope' => $this->formatScopes($this->scopes, $this->scopeSeparator), 'state' => $state,
+            'response_type' => 'code',
+        ];
+    }
 
 	/**
 	 * Get the POST fields for the token request.


### PR DESCRIPTION
This makes it a bit easier to add any additional parameters needed for building
the auth url in a provider. **For example**, in Facebook you might have the need to send the 
`auth_type` parameter for forcing *rerequests* and *reauthentications*:
  
```php 
// FacebookProvider
  
protected function getCodeRequestParameters($state)
{
    return array_merge(parent::getCodeRequestParameters($state), ['auth_type' => 'rerequest']);
}
```