### PR TITLE
Fix for undefined index error when email is hidden

### DIFF
--- a/src/Two/GithubProvider.php
+++ b/src/Two/GithubProvider.php
@@ -49,7 +49,7 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
     {
         return (new User)->setRaw($user)->map([
             'id' => $user['id'], 'nickname' => $user['login'], 'name' => array_get($user, 'name'),
-            'email' => $user['email'], 'avatar' => $user['avatar_url'],
+            'email' => isset($user['email']) ? $user['email'] : null, 'avatar' => $user['avatar_url'],
         ]);
     }
 }

--- a/src/Two/GithubProvider.php
+++ b/src/Two/GithubProvider.php
@@ -49,7 +49,7 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
     {
         return (new User)->setRaw($user)->map([
             'id' => $user['id'], 'nickname' => $user['login'], 'name' => array_get($user, 'name'),
-            'email' => isset($user['email']) ? $user['email'] : null, 'avatar' => $user['avatar_url'],
+            'email' => array_get($user, 'email'), 'avatar' => $user['avatar_url'],
         ]);
     }
 }


### PR DESCRIPTION
Same fix as the FB Provider. In Github (at least with new accounts) the email is set to be hidden by default in the user profile and this causes an error since that field won't be available for Socialite's **mapUserToObject** method.

Undefined index error before fix:

![socialite-github-noemail-error](https://cloud.githubusercontent.com/assets/1437923/6340378/ddc77c34-bb7b-11e4-8cbb-959ed0e6d20f.png)

Fallback null value for missing email after fix:

![socialite-github-fix](https://cloud.githubusercontent.com/assets/1437923/6340379/ddc7b014-bb7b-11e4-89b7-18cb72207868.png)
