### PR TITLE
Override of user method in Twitter Provider.

### DIFF
--- a/src/One/TwitterProvider.php
+++ b/src/One/TwitterProvider.php
@@ -2,6 +2,29 @@
 
 class TwitterProvider extends AbstractProvider
 {
+    /**
+     * Get the User instance for the authenticated user.
+     * Overridden to provide access to the urls property that comes back from the
+     * OAuth library
+     *
+     * @return \Laravel\Socialite\One\User
+     */
+    public function user()
+    {
+        if (! $this->hasNecessaryVerifier()) {
+            throw new \InvalidArgumentException("Invalid request. Missing OAuth verifier.");
+        }
 
-    //
+        $user = $this->server->getUserDetails($token = $this->getToken());
+
+        $instance = (new User)->setRaw(array_merge($user->extra, $user->urls))
+                ->setToken($token->getIdentifier(), $token->getSecret());
+
+        return $instance->map([
+            'id' => $user->uid, 'nickname' => $user->nickname,
+            'name' => $user->name, 'email' => $user->email, 'avatar' => $user->imageUrl,
+        ]);
+    }
+
 }
+


### PR DESCRIPTION
This pull request fixes an issue where several properties about a Twitter user are discarded, namely any profile background image URLs, as well as the https version of the avatar URL.

The user object coming back from `League\OAuth1\Client\Server\Twitter::userDetails()` separates all the data about a Twitter user's URLs (`profile_background_image_url`, `profile_background_image_url_https`, `profile_image_url`, `profile_image_url_https`, and `profile_banner_url`) into a property called `urls`, instead of the `extra` property that contains all the additional user data. This happens here: https://github.com/thephpleague/oauth1-client/blob/master/src/Client/Server/Twitter.php#L57

The issue stems from this line: https://github.com/laravel/socialite/blob/2.0/src/One/AbstractProvider.php#L65

Because the data from the `$user` object is separated out into two properties, some of it is discarded. The `user()` method only pulls in data from the `$user->extra` property, while the data from the  `$user->urls` property is incorrectly discarded.