### PR TITLE
Added redirect($rerequest) option to force permission screen

### DIFF
--- a/src/Contracts/Provider.php
+++ b/src/Contracts/Provider.php
@@ -6,9 +6,11 @@ interface Provider
     /**
      * Redirect the user to the authentication page for the provider.
      *
+     * @param bool $rerequest Whether or not to rerequest permissions.
+     *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function redirect();
+    public function redirect($rerequest = false);
 
     /**
      * Get the User instance for the authenticated user.

--- a/src/One/AbstractProvider.php
+++ b/src/One/AbstractProvider.php
@@ -38,9 +38,11 @@ abstract class AbstractProvider implements ProviderContract
     /**
      * Redirect the user to the authentication page for the provider.
      *
+     * @param bool $rerequest Whether or not to rerequest permissions.
+     *
      * @return RedirectResponse
      */
-    public function redirect()
+    public function redirect($rerequest = false)
     {
         $this->request->getSession()->set(
             'oauth.temp', $temp = $this->server->getTemporaryCredentials()

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -50,6 +50,13 @@ abstract class AbstractProvider implements ProviderContract
     protected $encodingType = PHP_QUERY_RFC1738;
 
     /**
+     * Should permissions be rerequested?
+     *
+     * @var bool
+     */
+    protected $rerequest = false;
+
+    /**
      * Create a new provider instance.
      *
      * @param  Request  $request
@@ -100,13 +107,17 @@ abstract class AbstractProvider implements ProviderContract
     /**
      * Redirect the user of the application to the provider's authentication screen.
      *
+     * @param bool $rerequest Whether or not to rerequest permissions.
+     *
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function redirect()
+    public function redirect($rerequest = false)
     {
         $this->request->getSession()->set(
             'state', $state = sha1(time().$this->request->getSession()->get('_token'))
         );
+
+        $this->rerequest = $rerequest;
 
         return new RedirectResponse($this->getAuthUrl($state));
     }

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -31,7 +31,9 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase('https://www.facebook.com/'.$this->version.'/dialog/oauth', $state);
+        $rerequest = ($this->rerequest) ? '&auth_type=rerequest' : '';
+
+        return $this->buildAuthUrlFromBase('https://www.facebook.com/'.$this->version.'/dialog/oauth', $state) . $rerequest;
     }
 
     /**

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -28,7 +28,9 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase('https://accounts.google.com/o/oauth2/auth', $state);
+        $rerequest = ($this->rerequest) ? '&approval_prompt=force' : '';
+
+        return $this->buildAuthUrlFromBase('https://accounts.google.com/o/oauth2/auth', $state) . $rerequest;
     }
 
     /**

--- a/tests/FacebookProviderTest.php
+++ b/tests/FacebookProviderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Http\Request;
+use Laravel\Socialite\Two\User;
+use Laravel\Socialite\Two\FacebookProvider;
+
+class FacebookProviderTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testRerequestParameterAddedToUrl()
+	{
+		$request = Request::create('foo');
+		$request->setSession($session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface'));
+		$session->shouldReceive('get')->once()->with('_token')->andReturn('token');
+
+		$state = null;
+
+		$session->shouldReceive('set')->once()->with('state',m::on(function($s) use (&$state) {
+			$state = $s;
+			return true;	
+		}));
+
+		$provider = new FacebookProvider($request, 'client_id', 'client_secret', 'redirect');
+
+		$response = $provider->redirect(true);
+
+		$this->assertEquals('https://www.facebook.com/v2.2/dialog/oauth?client_id=client_id&redirect_uri=redirect&scope=email&state='.$state.'&response_type=code&auth_type=rerequest', $response->getTargetUrl());
+	}
+
+	public function testRerequestParameterMissingByDefault()
+	{
+		$request = Request::create('foo');
+		$request->setSession($session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface'));
+		$session->shouldReceive('get')->once()->with('_token')->andReturn('token');
+
+		$state = null;
+
+		$session->shouldReceive('set')->once()->with('state',m::on(function($s) use (&$state) {
+			$state = $s;
+			return true;	
+		}));
+
+		$provider = new FacebookProvider($request, 'client_id', 'client_secret', 'redirect');
+
+		$response = $provider->redirect();
+
+		$this->assertEquals('https://www.facebook.com/v2.2/dialog/oauth?client_id=client_id&redirect_uri=redirect&scope=email&state='.$state.'&response_type=code', $response->getTargetUrl());
+	}
+
+}

--- a/tests/GoogleProviderTest.php
+++ b/tests/GoogleProviderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Http\Request;
+use Laravel\Socialite\Two\User;
+use Laravel\Socialite\Two\GoogleProvider;
+
+class GoogleProviderTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testRerequestParameterAddedToUrl()
+	{
+		$request = Request::create('foo');
+		$request->setSession($session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface'));
+		$session->shouldReceive('get')->once()->with('_token')->andReturn('token');
+
+		$state = null;
+
+		$session->shouldReceive('set')->once()->with('state',m::on(function($s) use (&$state) {
+			$state = $s;
+			return true;	
+		}));
+
+		$provider = new GoogleProvider($request, 'client_id', 'client_secret', 'redirect');
+
+		$response = $provider->redirect(true);
+
+		$this->assertEquals('https://accounts.google.com/o/oauth2/auth?client_id=client_id&redirect_uri=redirect&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fplus.me+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fplus.login+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fplus.profile.emails.read&state='.$state.'&response_type=code&approval_prompt=force', $response->getTargetUrl());
+	}
+
+	public function testRerequestParameterMissingByDefault()
+	{
+		$request = Request::create('foo');
+		$request->setSession($session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface'));
+		$session->shouldReceive('get')->once()->with('_token')->andReturn('token');
+
+		$state = null;
+
+		$session->shouldReceive('set')->once()->with('state',m::on(function($s) use (&$state) {
+			$state = $s;
+			return true;	
+		}));
+
+		$provider = new GoogleProvider($request, 'client_id', 'client_secret', 'redirect');
+
+		$response = $provider->redirect();
+
+		$this->assertEquals('https://accounts.google.com/o/oauth2/auth?client_id=client_id&redirect_uri=redirect&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fplus.me+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fplus.login+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fplus.profile.emails.read&state='.$state.'&response_type=code', $response->getTargetUrl());
+	}
+
+}


### PR DESCRIPTION
This PR adds the ability to force the permissions screen again in Facebook and Google. Socialite as is doesn't allow for this behaviour. If a user allows the app access but drops, for example, the `email` permission in the process, Socialite becomes a bit useless.

It's a drop in that doesn't change the established behaviour of Socialite installations.

You would use it like so: `return $socialite->with($provider)->redirect(true);`

This still works as expected: `return $socialite->with($provider)->redirect();`

Additional unit tests included specifically for this feature.