### PR TITLE
Add email to github user data - second fix

### DIFF
--- a/src/Two/GithubProvider.php
+++ b/src/Two/GithubProvider.php
@@ -33,6 +33,7 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
+        $this->token = $token;
         $response = $this->getHttpClient()->get('https://api.github.com/user?access_token='.$token, [
             'headers' => [
                 'Accept' => 'application/vnd.github.v3+json',
@@ -41,12 +42,35 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
 
         return json_decode($response->getBody(), true);
     }
-
+    
+    /**
+     * {@inheritdoc}
+     */
+    private function getUserEmailByToken($token)
+    {
+        $email = null;
+		$response = $this->getHttpClient()->get('https://api.github.com/user/emails?access_token='.$token, [
+				'headers' => [
+						'Accept' => 'application/vnd.github.v3+json',
+				],
+		]);
+		$userEmails = json_decode($response->getBody(), true);
+        foreach($userEmails AS $key => $array) {
+			if($array['primary'] == true && $array['verified'] == true) {
+				$email = $array['email'];
+			}
+		}
+		return $email;
+    }
+    
     /**
      * {@inheritdoc}
      */
     protected function mapUserToObject(array $user)
     {
+        if(is_null(array_get($user, 'email'))) {
+            $user['email'] = $this->getUserEmailByToken($this->token);
+        }
         return (new User)->setRaw($user)->map([
             'id' => $user['id'], 'nickname' => $user['login'], 'name' => array_get($user, 'name'),
             'email' => array_get($user, 'email'), 'avatar' => $user['avatar_url'],


### PR DESCRIPTION
In some cases the result from oAuth of github has not the user:email scope. In that case here is an business development quick fix with a second api call to POST /user/emails to get the list of mails for an user. The fix will store the primary mail address from list.
Got by: https://developer.github.com/v3/users/emails/

Another thing, do you have any idea how to fetch an [email address for an twitter user](https://github.com/laravel/framework/issues/8218)? 