### PR TITLE
Added getOAuthVersion() method to AbstractProvider classes.

### DIFF
--- a/src/Contracts/Provider.php
+++ b/src/Contracts/Provider.php
@@ -2,7 +2,6 @@
 
 interface Provider
 {
-
     /**
      * Redirect the user to the authentication page for the provider.
      *
@@ -16,4 +15,11 @@ interface Provider
      * @return \Laravel\Socialite\Contracts\User
      */
     public function user();
+
+    /**
+     * Returns version of OAuth protocol implementation.
+     *
+     * @return int
+     */
+    public function getOAuthVersion();
 }

--- a/src/One/AbstractProvider.php
+++ b/src/One/AbstractProvider.php
@@ -107,4 +107,14 @@ abstract class AbstractProvider implements ProviderContract
 
         return $this;
     }
+
+    /**
+     * Returns version of OAuth protocol implementation.
+     *
+     * @return int
+     */
+    public function getOAuthVersion()
+    {
+        return 1;
+    }
 }

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -1,5 +1,6 @@
 <?php namespace Laravel\Socialite\Two;
 
+use GuzzleHttp\Client;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Laravel\Socialite\Contracts\Provider as ProviderContract;
@@ -99,7 +100,7 @@ abstract class AbstractProvider implements ProviderContract
      * Map the raw user array to a Socialite User instance.
      *
      * @param  array  $user
-     * @return \Laravel\Socialite\User
+     * @return \Laravel\Socialite\Two\User
      */
     abstract protected function mapUserToObject(array $user);
 
@@ -265,11 +266,11 @@ abstract class AbstractProvider implements ProviderContract
     /**
      * Get a fresh instance of the Guzzle HTTP client.
      *
-     * @return \GuzzleHttp\Client
+     * @return Client
      */
     protected function getHttpClient()
     {
-        return new \GuzzleHttp\Client;
+        return new Client;
     }
 
     /**
@@ -315,5 +316,15 @@ abstract class AbstractProvider implements ProviderContract
         $this->stateless = true;
 
         return $this;
+    }
+
+    /**
+     * Returns version of OAuth protocol implementation.
+     *
+     * @return int
+     */
+    public function getOAuthVersion()
+    {
+        return 2;
     }
 }


### PR DESCRIPTION
I added ```getOAuthVersion()``` method to AbstractProvider classes and related Contract. This method returns ```1``` for v1 implementations (namely Twitter) and ```2``` for their v2 counterparts. Additionally, I fixed indentation from spaces to tabs, as Laravel project requires.