### PR TITLE
Added support for Facebook popup dialog

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -26,6 +26,13 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      */
     protected $scopes = ['email'];
 
+	/**
+	 * Display the dialog in a popup view.
+	 *
+	 * @var bool
+	 */
+	private $popup = false;
+
     /**
      * {@inheritdoc}
      */
@@ -90,5 +97,32 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
             'id' => $user['id'], 'nickname' => null, 'name' => $user['first_name'].' '.$user['last_name'],
             'email' => isset($user['email']) ? $user['email'] : null, 'avatar' => $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture?type=normal',
         ]);
+    }
+
+	/**
+	 * Set the dialog to be displayed as a popup.
+	 *
+	 * @return $this
+	 */
+	public function asPopup()
+	{
+		$this->popup = true;
+
+		return $this;
+	}
+
+	/**
+     * {@inheritdoc}
+     */
+    protected function getCodeFields($state = null)
+    {
+		$fields = parent::getCodeFields($state);
+
+		if($this->popup)
+		{
+			$fields['display'] = 'popup';
+		}
+
+		return $fields;
     }
 }


### PR DESCRIPTION
When running the callback in a popup, Facebook recommends using ```&display=popup``` in order for the dialog to render properly.