### PR TITLE
Adding support for direct request using access token

### DIFF
--- a/src/Contracts/Provider.php
+++ b/src/Contracts/Provider.php
@@ -16,4 +16,12 @@ interface Provider
      * @return \Laravel\Socialite\Contracts\User
      */
     public function user();
+
+    /**
+     * Get the User instance with access token
+     *
+     * @param $token
+     * @return \Laravel\Socialite\Contracts\User
+     */
+    public function userWithToken($token);
 }

--- a/src/One/AbstractProvider.php
+++ b/src/One/AbstractProvider.php
@@ -60,7 +60,19 @@ abstract class AbstractProvider implements ProviderContract
             throw new \InvalidArgumentException("Invalid request. Missing OAuth verifier.");
         }
 
-        $user = $this->server->getUserDetails($token = $this->getToken());
+        return $this->userWithToken($this->getToken());
+    }
+
+
+    /**
+     * Get the User instance with access token
+     *
+     * @param \League\OAuth1\Client\Credentials\TokenCredentials $token
+     * @return \Laravel\Socialite\One\User
+     */
+    public function userWithToken($token)
+    {
+        $user = $this->server->getUserDetails($token);
 
         $instance = (new User)->setRaw($user->extra)
                 ->setToken($token->getIdentifier(), $token->getSecret());

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -150,9 +150,18 @@ abstract class AbstractProvider implements ProviderContract
             throw new InvalidStateException;
         }
 
-        $user = $this->mapUserToObject($this->getUserByToken(
-            $token = $this->getAccessToken($this->getCode())
-        ));
+        return $this->userWithToken($this->getAccessToken($this->getCode()));
+    }
+
+    /**
+     * Get the User instance with access token
+     *
+     * @param string $token
+     * @return \Laravel\Socialite\Contracts\User
+     */
+    public function userWithToken($token)
+    {
+        $user = $this->mapUserToObject($this->getUserByToken($token));
 
         return $user->setToken($token);
     }


### PR DESCRIPTION
When developing a rest api for authenticating mobile users android or ios app get access token via native apps, then send this access token to server.
I needed to query user using this access_token. 

$token = "access token from mobile device";
$user = Socialize::with('facebook')->userWithToken($token);