### PR TITLE
Add LinkedIn Provider

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -69,6 +69,20 @@ class SocialiteManager extends Manager implements Contracts\Factory
     }
 
     /**
+     * Create an instance of the specified driver.
+     *
+     * @return \Laravel\Socialite\Two\AbstractProvider
+     */
+    protected function createLinkedinDriver()
+    {
+        $config = $this->app['config']['services.linkedin'];
+
+        return $this->buildProvider(
+          'Laravel\Socialite\Two\LinkedInProvider', $config
+        );
+    }
+
+    /**
      * Build an OAuth 2 provider instance.
      *
      * @param  string  $provider

--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -1,0 +1,58 @@
+<?php namespace Laravel\Socialite\Two;
+
+use GuzzleHttp\ClientInterface;
+
+class LinkedInProvider extends AbstractProvider implements ProviderInterface
+{
+
+    /**
+     * The scopes being requested.
+     *
+     * @var array
+     */
+    protected $scopes = ['r_basicprofile', 'r_emailaddress'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://www.linkedin.com/uas/oauth2/authorization', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://www.linkedin.com/uas/oauth2/accessToken?grant_type=authorization_code';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $fields = 'id,email-address,first-name,last-name,formatted-name,headline,picture-url,public-profile-url,location';
+
+        $response = $this->getHttpClient()->get("https://api.linkedin.com/v1/people/~:({$fields})", [
+          'headers' => [
+            'x-li-format' => 'json',
+            'Authorization' => 'Bearer ' . $token,
+          ],
+        ]);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id' => $user['id'], 'nickname' => null, 'name' => array_get($user, 'formattedName'),
+            'email' => array_get($user, 'emailAddress'), 'avatar' => $user['pictureUrl'],
+        ]);
+    }
+}


### PR DESCRIPTION
This adds a LinkedIn Provider with basis profile + email fields.
Besides the name/email/avatar, some additional raw fields are requested.

This currently doesn't work on the latest Guzzle 6 release, until a release with https://github.com/guzzle/psr7/commit/962735c754f2a562a619b456a3aa4e614f0e5360 is tagged.

