### PR TITLE
Add original/large avatars

### DIFF
--- a/src/One/TwitterProvider.php
+++ b/src/One/TwitterProvider.php
@@ -19,6 +19,7 @@ class TwitterProvider extends AbstractProvider
         return $instance->map([
             'id' => $user->uid, 'nickname' => $user->nickname,
             'name' => $user->name, 'email' => $user->email, 'avatar' => $user->imageUrl,
+            'avatar_original' => str_replace('_normal', '', $user->imageUrl),
         ]);
     }
 

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -93,9 +93,12 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user)
     {
+        $avatarUrl = $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture';
+
         return (new User)->setRaw($user)->map([
             'id' => $user['id'], 'nickname' => null, 'name' => $user['first_name'].' '.$user['last_name'],
-            'email' => isset($user['email']) ? $user['email'] : null, 'avatar' => $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture?type=normal',
+            'email' => isset($user['email']) ? $user['email'] : null, 'avatar' => $avatarUrl.'?type=normal',
+            'avatar_original' => $avatarUrl.'?width=1920',
         ]);
     }
 

--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -9,10 +9,10 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
      * @var array
      */
     protected $scopes = ['r_basicprofile', 'r_emailaddress'];
-    
+
     /**
      * The fields that are included in the profile.
-     * 
+     *
      * @var array
      */
     protected $fields = [
@@ -47,10 +47,10 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
         $url = 'https://api.linkedin.com/v1/people/~:('.$fields.')';
 
         $response = $this->getHttpClient()->get($url, [
-          'headers' => [
-            'x-li-format' => 'json',
-            'Authorization' => 'Bearer ' . $token,
-          ],
+            'headers' => [
+                'x-li-format' => 'json',
+                'Authorization' => 'Bearer ' . $token,
+            ],
         ]);
 
         return json_decode($response->getBody(), true);
@@ -63,7 +63,8 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
     {
         return (new User)->setRaw($user)->map([
             'id' => $user['id'], 'nickname' => null, 'name' => array_get($user, 'formattedName'),
-            'email' => array_get($user, 'emailAddress'), 'avatar' => $user['pictureUrl'],
+            'email' => array_get($user, 'emailAddress'), 'avatar' => array_get($user, 'pictureUrl'),
+            'avatar_original' => array_get($user, 'pictureUrls.values.0'),
         ]);
     }
 }


### PR DESCRIPTION
This adds an attribute `avatar_original` with the larger images for LinkedIn, Twitter and Facebook.
The normale avatar pictures are pretty small, so if you want to use them for anything else then a tiny thumb, this makes that possible.

LinkedIn: Supplies original image when request
Twitter: Suggests so strip `_normal`: https://dev.twitter.com/overview/general/user-profile-images-and-banners
Facebook: Has a width/height parameter, just supply a large constraint (1920) in this case)

Perhaps other providers have the same possibilities, but not sure. If more support this, we could add a method to the AbstractUser perhaps?