### PR TITLE
Add refreshToken fetch and action

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -183,8 +183,8 @@ abstract class AbstractProvider implements ProviderContract
             throw new InvalidStateException;
         }
 
-        $token = $this->getToken($this->getCode())
-        $user = $this->mapUserToObject($this->getUserByToken($token->accessToken));
+        $token = $this->getToken($this->getCode());
+        $user = $this->mapUserToObject($this->getUserByToken($token->token));
 
         return $user->setToken($token->accessToken, $token->refreshToken);
     }

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -252,7 +252,7 @@ abstract class AbstractProvider implements ProviderContract
     /**
      * Get an access token from a previous refresh token.
      *
-     * @param  string $token
+     * @param  string  $token
      * @return string
      */
     public function refreshToken($token)
@@ -301,6 +301,19 @@ abstract class AbstractProvider implements ProviderContract
     protected function getCode()
     {
         return $this->request->input('code');
+    }
+
+    /**
+     * Add scope to the requested access.
+     *
+     * @param  string  $scope
+     * @return $this
+     */
+    public function addScope($scope)
+    {
+        $this->scopes[] = $scope;
+
+        return $this;
     }
 
     /**

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -27,7 +27,7 @@ abstract class AbstractProvider implements ProviderContract
      * @var string
      */
     protected $clientSecret;
-    
+
     /**
      * The redirect URL.
      *
@@ -184,7 +184,7 @@ abstract class AbstractProvider implements ProviderContract
         }
 
         $token = $this->getToken($this->getCode());
-        $user = $this->mapUserToObject($this->getUserByToken($token->token));
+        $user = $this->mapUserToObject($this->getUserByToken($token->accessToken));
 
         return $user->setToken($token->accessToken, $token->refreshToken);
     }

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -268,7 +268,7 @@ abstract class AbstractProvider implements ProviderContract
             $postKey => $this->getRefreshTokenFields($token),
         ]);
 
-        return $this->parseRefreshToken($response->getBody());
+        return $this->parseToken($response->getBody());
     }
 
     /**
@@ -283,18 +283,6 @@ abstract class AbstractProvider implements ProviderContract
             'client_id' => $this->clientId, 'client_secret' => $this->clientSecret,
             'refresh_token' => $token, 'grant_type' => 'refresh_token'
         ];
-    }
-
-    /**
-     * Get the access token from the refresh token response body.
-     *
-     * @param  string  $body
-     * @return string
-     */
-    protected function parseRefreshToken($body)
-    {
-        $data = json_decode($body, true);
-        return $data['access_token'];
     }
 
     /**

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -186,7 +186,7 @@ abstract class AbstractProvider implements ProviderContract
         $token = $this->getToken($this->getCode());
         $user = $this->mapUserToObject($this->getUserByToken($token->accessToken));
 
-        return $user->setToken($token->accessToken, $token->refreshToken);
+        return $user->setToken($token->accessToken, $token->refreshToken, $token->expiresIn);
     }
 
     /**
@@ -246,7 +246,11 @@ abstract class AbstractProvider implements ProviderContract
     protected function parseToken($body)
     {
         $data = json_decode($body, true);
-        return new Token($data['access_token'], isset($data['refresh_token']) ? $data['refresh_token'] : null);
+        return new Token(
+            $data['access_token'],
+            isset($data['refresh_token']) ? $data['refresh_token'] : null,
+            isset($data['expires_in']) ? $data['expires_in'] : null
+        );
     }
 
     /**

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -183,11 +183,10 @@ abstract class AbstractProvider implements ProviderContract
             throw new InvalidStateException;
         }
 
-        $user = $this->mapUserToObject($this->getUserByToken(
-            $token = $this->getAccessToken($this->getCode())
-        ));
+        $token = $this->getToken($this->getCode())
+        $user = $this->mapUserToObject($this->getUserByToken($token->accessToken));
 
-        return $user->setToken($token);
+        return $user->setToken($token->accessToken, $token->refreshToken);
     }
 
     /**
@@ -207,12 +206,12 @@ abstract class AbstractProvider implements ProviderContract
     }
 
     /**
-     * Get the access token for the given code.
+     * Get the token for the given code.
      *
      * @param  string  $code
-     * @return string
+     * @return \Laravel\Socialite\Two\Token
      */
-    public function getAccessToken($code)
+    public function getToken($code)
     {
         $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
 
@@ -221,7 +220,7 @@ abstract class AbstractProvider implements ProviderContract
             $postKey => $this->getTokenFields($code),
         ]);
 
-        return $this->parseAccessToken($response->getBody());
+        return $this->parseToken($response->getBody());
     }
 
     /**
@@ -242,11 +241,56 @@ abstract class AbstractProvider implements ProviderContract
      * Get the access token from the token response body.
      *
      * @param  string  $body
+     * @return \Laravel\Socialite\Two\Token
+     */
+    protected function parseToken($body)
+    {
+        $data = json_decode($body, true);
+        return new Token($data['access_token'], isset($data['refresh_token']) ? $data['refresh_token'] : null);
+    }
+
+    /**
+     * Get an access token from a previous refresh token.
+     *
+     * @param  string $token
      * @return string
      */
-    protected function parseAccessToken($body)
+    public function refreshToken($token)
     {
-        return json_decode($body, true)['access_token'];
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
+            'headers' => ['Accept' => 'application/json'],
+            $postKey => $this->getRefreshTokenFields($token),
+        ]);
+
+        return $this->parseRefreshToken($response->getBody());
+    }
+
+    /**
+     * Get the POST fields for the token request.
+     *
+     * @param  string  $code
+     * @return array
+     */
+    protected function getRefreshTokenFields($token)
+    {
+        return [
+            'client_id' => $this->clientId, 'client_secret' => $this->clientSecret,
+            'refresh_token' => $token, 'grant_type' => 'refresh_token'
+        ];
+    }
+
+    /**
+     * Get the access token from the refresh token response body.
+     *
+     * @param  string  $body
+     * @return string
+     */
+    protected function parseRefreshToken($body)
+    {
+        $data = json_decode($body, true);
+        return $data['access_token'];
     }
 
     /**

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -50,28 +50,28 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     }
 
     /**
-     * Get the access token for the given code.
+     * Get the token for the given code.
      *
      * @param  string  $code
-     * @return string
+     * @return \Laravel\Socialite\Two\Token
      */
-    public function getAccessToken($code)
+    public function getToken($code)
     {
         $response = $this->getHttpClient()->get($this->getTokenUrl(), [
             'query' => $this->getTokenFields($code),
         ]);
 
-        return $this->parseAccessToken($response->getBody());
+        return $this->parseToken($response->getBody());
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function parseAccessToken($body)
+    protected function parseToken($body)
     {
         parse_str($body);
 
-        return $access_token;
+        return new Token($access_token);
     }
 
     /**

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -7,6 +7,13 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
 {
 
     /**
+     * Ask for an offline token.
+     *
+     * @var bool
+     */
+    protected $offline = false;
+
+    /**
      * The separating character for the requested scopes.
      *
      * @var string
@@ -41,12 +48,12 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     }
 
     /**
-     * Get the access token for the given code.
+     * Get the token for the given code.
      *
      * @param  string  $code
-     * @return string
+     * @return \Laravel\Socialite\Two\Token
      */
-    public function getAccessToken($code)
+    public function getToken($code)
     {
         $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
 
@@ -54,7 +61,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
             $postKey => $this->getTokenFields($code),
         ]);
 
-        return $this->parseAccessToken($response->getBody());
+        return $this->parseToken($response->getBody());
     }
 
     /**
@@ -97,5 +104,19 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
             'id' => $user['id'], 'nickname' => array_get($user, 'nickname'), 'name' => $user['displayName'],
             'email' => $user['emails'][0]['value'], 'avatar' => array_get($user, 'image')['url'],
         ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getCodeFields($state = null)
+    {
+        $fields = parent::getCodeFields($state);
+
+        if ($this->offline) {
+            $fields['access_type'] = 'offline';
+        }
+
+        return $fields;
     }
 }

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -119,4 +119,16 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
 
         return $fields;
     }
+
+    /**
+     * Set the token as available offline.
+     *
+     * @return $this
+     */
+    public function asOffline()
+    {
+        $this->offline = true;
+
+        return $this;
+    }
 }

--- a/src/Two/Token.php
+++ b/src/Two/Token.php
@@ -8,7 +8,7 @@ class Token
      *
      * @var string
      */
-    public $token;
+    public $accessToken;
 
     /**
      * The refresh token.
@@ -24,9 +24,9 @@ class Token
      * @param  string  $refreshToken
      * @return $this
      */
-    public function __construct($token, $refreshToken = null)
+    public function __construct($accessToken, $refreshToken = null)
     {
-        $this->token = $token;
+        $this->accessToken = $accessToken;
         $this->refreshToken = $refreshToken;
 
         return $this;

--- a/src/Two/Token.php
+++ b/src/Two/Token.php
@@ -1,19 +1,17 @@
 <?php namespace Laravel\Socialite\Two;
 
-use Laravel\Socialite\AbstractUser;
-
-class User extends AbstractUser
+class Token
 {
 
     /**
-     * The user's access token.
+     * The access token.
      *
      * @var string
      */
     public $token;
 
     /**
-     * The user's refresh token.
+     * The refresh token.
      *
      * @var string
      */
@@ -23,9 +21,10 @@ class User extends AbstractUser
      * Set the token on the user.
      *
      * @param  string  $token
+     * @param  string  $refreshToken
      * @return $this
      */
-    public function setToken($token, $refreshToken)
+    public function __construct($token, $refreshToken = null)
     {
         $this->token = $token;
         $this->refreshToken = $refreshToken;

--- a/src/Two/Token.php
+++ b/src/Two/Token.php
@@ -18,16 +18,24 @@ class Token
     public $refreshToken;
 
     /**
+     * The access token expiration delay.
+     *
+     * @var int
+     */
+    public $expiresIn;
+
+    /**
      * Set the token on the user.
      *
      * @param  string  $token
      * @param  string  $refreshToken
      * @return $this
      */
-    public function __construct($accessToken, $refreshToken = null)
+    public function __construct($accessToken, $refreshToken = null, $expiresIn = null)
     {
         $this->accessToken = $accessToken;
         $this->refreshToken = $refreshToken;
+        $this->expiresIn = $expiresIn;
 
         return $this;
     }

--- a/src/Two/User.php
+++ b/src/Two/User.php
@@ -20,15 +20,23 @@ class User extends AbstractUser
     public $refreshToken;
 
     /**
+     * The user's access token expiration delay.
+     *
+     * @var int
+     */
+    public $tokenExpiresIn;
+
+    /**
      * Set the token on the user.
      *
      * @param  string  $token
      * @return $this
      */
-    public function setToken($token, $refreshToken)
+    public function setToken($token, $refreshToken, $tokenExpiresIn)
     {
         $this->token = $token;
         $this->refreshToken = $refreshToken;
+        $this->tokenExpiresIn = $tokenExpiresIn;
 
         return $this;
     }


### PR DESCRIPTION
Add two fields in the user return: refreshToken and tokenExpiresIn so that if requested, these tokens can be used later on.
Add method in OAuth2 providers to refresh an accessToken from a refreshToken.