### PR TITLE
Update Facebook Graph API version to v2.4

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -17,7 +17,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      *
      * @var string
      */
-    protected $version = 'v2.3';
+    protected $version = 'v2.4';
 
     /**
      * The scopes being requested.


### PR DESCRIPTION
Version 2.4 of the Facebook Graph API [was released today](https://developers.facebook.com/docs/apps/changelog/).

This is technically a BC since each version of the Graph API has it's own set of breaking changes. The developer shouldn't rely on a default Graph API version fallback for their requests since each minor upgrade could break their Facebook app.

There should be a way to set the Graph API version via the config so that the developer can manually upgrade the Graph version and test the app before deploying to production.

I was going to submit a PR that would achieve this but since the `AbstractProvider` doesn't seem to allow arbitrary config injection via the constructor, I'm assuming I'd need a special setter method on the `FacebookProvider` for the Graph API version and then have the `SocialiteManager` set it from the `createFacebookDriver()` method if the config value exists.

Let me know if that sounds about right and I can send another PR for that. :)