### PR TITLE
Add support for custom request parameters to the redirect response

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -39,6 +39,13 @@ abstract class AbstractProvider implements ProviderContract
     protected $redirectUrl;
 
     /**
+     * The custom parameters to be sent.
+     *
+     * @var array
+     */
+    protected $parameters = [];
+
+    /**
      * The scopes being requested.
      *
      * @var array
@@ -160,6 +167,8 @@ abstract class AbstractProvider implements ProviderContract
             $fields['state'] = $state;
         }
 
+        $fields = array_merge($fields, $this->parameters);
+
         return $fields;
     }
 
@@ -258,6 +267,19 @@ abstract class AbstractProvider implements ProviderContract
     protected function getCode()
     {
         return $this->request->input('code');
+    }
+
+    /**
+     * Set the custom parameters of the request.
+     *
+     * @param  array  $parameters
+     * @return $this
+     */
+    public function parameters(array $parameters)
+    {
+        $this->parameters = $parameters;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This pull request adds the ability to set arbitrary request parameters to the provider redirect response. 

The use case for this feature comes from the many popular OAuth2 providers that support a variety of custom parameters. In particular, I was attempting to use the `hd` parameter (Google documentation [here](https://developers.google.com/identity/protocols/OpenIDConnect?hl=en#hd-param)) that Google OAuth2 allows for, but I did not see a way to utilize that using Socialite.

To use this, it is quite similar to the `scopes` feature:

```php
return $provider
    ->scopes(['email', 'profile'])
    ->parameters(['hd' => 'example.com'])
    ->redirect();
```