### PR TITLE
location and description fields are lost while twitter login

### DIFF
--- a/src/One/TwitterProvider.php
+++ b/src/One/TwitterProvider.php
@@ -17,7 +17,11 @@ class TwitterProvider extends AbstractProvider
 
         $user = $this->server->getUserDetails($token = $this->getToken());
 
-        $instance = (new User)->setRaw(array_merge($user->extra, $user->urls))
+        $instance = (new User)->setRaw(array_merge(
+            $user->extra,
+            $user->urls,
+            ['location' => $user->location, 'description' => $user->description]
+        ))
                 ->setToken($token->getIdentifier(), $token->getSecret());
 
         return $instance->map([

--- a/src/One/TwitterProvider.php
+++ b/src/One/TwitterProvider.php
@@ -21,8 +21,7 @@ class TwitterProvider extends AbstractProvider
             $user->extra,
             $user->urls,
             ['location' => $user->location, 'description' => $user->description]
-        ))
-                ->setToken($token->getIdentifier(), $token->getSecret());
+        ))->setToken($token->getIdentifier(), $token->getSecret());
 
         return $instance->map([
             'id' => $user->uid, 'nickname' => $user->nickname,

--- a/src/One/TwitterProvider.php
+++ b/src/One/TwitterProvider.php
@@ -17,11 +17,13 @@ class TwitterProvider extends AbstractProvider
 
         $user = $this->server->getUserDetails($token = $this->getToken());
 
-        $instance = (new User)->setRaw(array_merge(
-            $user->extra,
-            $user->urls,
-            ['location' => $user->location, 'description' => $user->description]
-        ))->setToken($token->getIdentifier(), $token->getSecret());
+        $instance = (new User)->setRaw(
+            array_merge(
+                $user->extra,
+                $user->urls,
+                ['location' => $user->location, 'description' => $user->description]
+            )
+        )->setToken($token->getIdentifier(), $token->getSecret());
 
         return $instance->map([
             'id' => $user->uid, 'nickname' => $user->nickname,


### PR DESCRIPTION
Here is the link of twitter's verify_credentials api:
https://dev.twitter.com/rest/reference/get/account/verify_credentials. 
It always sends "location" & "description" fields.

But the real problem is, in dependency of `league/oauth1-client` at https://github.com/thephpleague/oauth1-client/blob/master/src/Client/Server/Twitter.php#L51
we are setting these fields into `League\OAuth1\Client\Server\User` and these fields are pushed into used fields array https://github.com/thephpleague/oauth1-client/blob/master/src/Client/Server/Twitter.php#L59 and got removed from extra fields array.

And `Laravel\Socialite\One\User` model doesn't have these fields and it never mapped to any field of `Laravel\Socialite\One\User` model. https://github.com/laravel/socialite/blob/2.0/src/One/TwitterProvider.php#L23