### PR TITLE
Send appsecret_proof on FacebookProvider getUserByToken method.

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -85,7 +85,8 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get($this->graphUrl.'/'.$this->version.'/me?access_token='.$token.'&fields='.implode(',', $this->fields), [
+        $appsecret_proof= hash_hmac('sha256', $token, $this->clientSecret);
+        $response = $this->getHttpClient()->get($this->graphUrl.'/'.$this->version.'/me?access_token='.$token.'&appsecret_proof='.$appsecret_proof.'&fields='.implode(',', $this->fields), [
             'headers' => [
                 'Accept' => 'application/json',
             ],


### PR DESCRIPTION
Send appsecret_proof for Facebook App "Require App Secret" enabled setting.