### PR TITLE
Send appsecret_proof on FacebookProvider getUserByToken method.

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -85,7 +85,8 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get($this->graphUrl.'/'.$this->version.'/me?access_token='.$token.'&fields='.implode(',', $this->fields), [
+        $appsecret_proof = hash_hmac('sha256', $token, $this->clientSecret);
+        $response = $this->getHttpClient()->get($this->graphUrl.'/'.$this->version.'/me?access_token='.$token.'&appsecret_proof='.$appsecret_proof.'&fields='.implode(',', $this->fields), [
             'headers' => [
                 'Accept' => 'application/json',
             ],


### PR DESCRIPTION
This change makes better secured Server API calls.

There is a Facebook App setting named "Require App Secret".
When this setting is enabled every API call has to include a parameter called "appsecret_proof".
Facebook documentation recommends to enable this settings so that if a user's access token is stolen by a malicious software, every API call without an appsecret_proof will fail.

The app secret proof is a sha256 hash of your access token, using the app secret as the key. Here's what the call looks like in PHP:
```php
$appsecret_proof= hash_hmac('sha256', $access_token, $app_secret); 
```

Facebook Docs
- Verifying Graph API Calls with appsecret_proof: https://developers.facebook.com/docs/graph-api/securing-requests#appsecret_proof
- Login Security: https://developers.facebook.com/docs/facebook-login/security