### PR TITLE
Add the ability to specify which fields to return from the LinkedIn Provider

### DIFF
--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -79,4 +79,17 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
             'avatar_original' => array_get($user, 'pictureUrls.values.0'),
         ]);
     }
+
+    /**
+     * Set the user fields to request from LinkedIn.
+     *
+     * @param  array  $fields
+     * @return $this
+     */
+    public function fields(array $fields)
+    {
+        $this->fields = $fields;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Same method as is available for the [Facebook Provider](https://github.com/laravel/socialite/blob/2.0/src/Two/FacebookProvider.php#L131-L142), would be useful to allow this with LinkedIn too.