### PR TITLE
Allow for custom config

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -129,15 +129,14 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     public function formatConfig(array $config)
     {
-        $return = array();
-        $custom = array('client_id' => 'identifier', 'client_secret' => 'secret', 'redirect' => 'callback_uri');
+        $return = [];
+        $custom = ['client_id' => 'identifier', 'client_secret' => 'secret', 'redirect' => 'callback_uri'];
 
         foreach ($config as $key => $value) {
             // If there is a custom mapping for this config
             if (isset($custom[$key])) {
                 $return[ $custom[$key] ] = $value;
-            }
-            else {
+            } else {
                 $return[$key] = $value;
             }
         }

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -129,11 +129,20 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     public function formatConfig(array $config)
     {
-        return [
-            'identifier' => $config['client_id'],
-            'secret' => $config['client_secret'],
-            'callback_uri' => $config['redirect'],
-        ];
+        $return = array();
+        $custom = array('client_id' => 'identifier', 'client_secret' => 'secret', 'redirect' => 'callback_uri');
+
+        foreach ($config as $key => $value) {
+            // If there is a custom mapping for this config
+            if (isset($custom[$key])) {
+                $return[ $custom[$key] ] = $value;
+            }
+            else {
+                $return[$key] = $value;
+            }
+        }
+
+        return $return;
     }
 
     /**


### PR DESCRIPTION
The [JIRA Socialite Provider](https://github.com/SocialiteProviders/Jira) has a hardcoded JIRA base URL of "http://example.jira.com". Since JIRA is typically hosted on various company servers there is no one official URL that can be placed in here. There should be some clean way of setting this URL via config. But since the `formatConfig` method strips out all custom configs I needed to make some updates so I can pass the JIRA URL to the provider.

I submitted [a pull request](https://github.com/SocialiteProviders/Jira/pull/1) to the JIRA Socialite Provider repo to grab the custom config and populate that URL.