### PR TITLE
Fix Facebook name lexical order problem.

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -23,7 +23,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      *
      * @var array
      */
-    protected $fields = ['first_name', 'last_name', 'email', 'gender', 'verified'];
+    protected $fields = ['name', 'email', 'gender', 'verified'];
 
     /**
      * The scopes being requested.
@@ -103,12 +103,8 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     {
         $avatarUrl = $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture';
 
-        $firstName = isset($user['first_name']) ? $user['first_name'] : null;
-
-        $lastName = isset($user['last_name']) ? $user['last_name'] : null;
-
         return (new User)->setRaw($user)->map([
-            'id' => $user['id'], 'nickname' => null, 'name' => $firstName.' '.$lastName,
+            'id' => $user['id'], 'nickname' => null, 'name' => $user['name'],
             'email' => isset($user['email']) ? $user['email'] : null, 'avatar' => $avatarUrl.'?type=normal',
             'avatar_original' => $avatarUrl.'?width=1920',
         ]);


### PR DESCRIPTION
For most Chinese, Japanese and Korean people, lexical order of name is "{last}{first}". Facebook user can customize the order in Facebook settings. Instead of use "first_name" and "last_name", we can just change to use "name" fields. This changes can fix lexical order of name.