### PR TITLE
Replaced G+ by OpenID in scopes

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -19,9 +19,9 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      * @var array
      */
     protected $scopes = [
-        'https://www.googleapis.com/auth/plus.me',
-        'https://www.googleapis.com/auth/plus.login',
-        'https://www.googleapis.com/auth/plus.profile.emails.read',
+        'openid',
+        'profile',
+        'email',
     ];
 
     /**

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -19,7 +19,6 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      * @var array
      */
     protected $scopes = [
-        'openid',
         'profile',
         'email',
     ];


### PR DESCRIPTION
No need to specify anything related to "Google +". Some Google Apps accounts may have it disabled or G+ may not be usefull for an account.

I have checked the given changes for my own use (Google Apps) and they are working as expected (the mapping is correctly done).