### PR TITLE
Replaced G+ scopes by Google Sign

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -19,9 +19,8 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      * @var array
      */
     protected $scopes = [
-        'https://www.googleapis.com/auth/plus.me',
-        'https://www.googleapis.com/auth/plus.login',
-        'https://www.googleapis.com/auth/plus.profile.emails.read',
+        'profile',
+        'email',
     ];
 
     /**


### PR DESCRIPTION
When using Google Sign-in, using G+ is unnecessary and can be blocked with Google Apps.
Google+ can be disabled on Google Apps domains, or when enabled, it forces the user to subscribe to G+.