### PR TITLE
Make AbstractProvider::scopes() more intuitive

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -275,9 +275,19 @@ abstract class AbstractProvider implements ProviderContract
      */
     public function scopes(array $scopes)
     {
-        $this->scopes = $scopes;
+        $this->scopes = array_unique(array_merge($this->scopes, $scopes));
 
         return $this;
+    }
+	
+    /**
+     * Get the current scopes.
+     *
+     * @return array
+     */
+    public function getScopes()
+    {
+        return $this->scopes;
     }
 
     /**


### PR DESCRIPTION
Google and Facebook require certain scopes to login correctly so they
don't throw an error, which are included by default. However, when a
user adds their own scopes, it overrides these scopes that they don't
know about. This makes it merge them instead.