### PR TITLE
bitbucket oauth2

### DIFF
--- a/src/One/BitbucketProvider.php
+++ b/src/One/BitbucketProvider.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Laravel\Socialite\One;
-
-class BitbucketProvider extends AbstractProvider
-{
-    //
-}

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -79,6 +79,20 @@ class SocialiteManager extends Manager implements Contracts\Factory
     }
 
     /**
+     * Create an instance of the specified driver.
+     *
+     * @return \Laravel\Socialite\Two\AbstractProvider
+     */
+    protected function createBitbucketDriver()
+    {
+        $config = $this->app['config']['services.bitbucket'];
+
+        return $this->buildProvider(
+          'Laravel\Socialite\Two\BitbucketProvider', $config
+        );
+    }
+
+    /**
      * Build an OAuth 2 provider instance.
      *
      * @param  string  $provider
@@ -104,20 +118,6 @@ class SocialiteManager extends Manager implements Contracts\Factory
 
         return new TwitterProvider(
             $this->app['request'], new TwitterServer($this->formatConfig($config))
-        );
-    }
-
-    /**
-     * Create an instance of the specified driver.
-     *
-     * @return \Laravel\Socialite\One\AbstractProvider
-     */
-    protected function createBitbucketDriver()
-    {
-        $config = $this->app['config']['services.bitbucket'];
-
-        return new BitbucketProvider(
-            $this->app['request'], new BitbucketServer($this->formatConfig($config))
         );
     }
 

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -5,9 +5,7 @@ namespace Laravel\Socialite;
 use InvalidArgumentException;
 use Illuminate\Support\Manager;
 use Laravel\Socialite\One\TwitterProvider;
-use Laravel\Socialite\One\BitbucketProvider;
 use League\OAuth1\Client\Server\Twitter as TwitterServer;
-use League\OAuth1\Client\Server\Bitbucket as BitbucketServer;
 
 class SocialiteManager extends Manager implements Contracts\Factory
 {

--- a/src/Two/BitbucketProvider.php
+++ b/src/Two/BitbucketProvider.php
@@ -79,8 +79,8 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
     protected function mapUserToObject(array $user)
     {
         return (new User)->setRaw($user)->map([
-            'id' => $user['uuid'], 'nickname' => $user['username'], 
-            'name' => array_get($user, 'display_name'), 'email' => array_get($user, 'email'), 
+            'id' => $user['uuid'], 'nickname' => $user['username'],
+            'name' => array_get($user, 'display_name'), 'email' => array_get($user, 'email'),
             'avatar' => array_get($user, 'links.avatar.href'),
         ]);
     }
@@ -113,7 +113,7 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
     protected function getTokenFields($code)
     {
         return [
-            'code' => $code, 'redirect_uri' => $this->redirectUrl, 'grant_type' => 'authorization_code'
+            'code' => $code, 'redirect_uri' => $this->redirectUrl, 'grant_type' => 'authorization_code',
         ];
     }
 }

--- a/src/Two/BitbucketProvider.php
+++ b/src/Two/BitbucketProvider.php
@@ -79,10 +79,8 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
     protected function mapUserToObject(array $user)
     {
         return (new User)->setRaw($user)->map([
-            'id' => $user['uuid'], 
-            'nickname' => $user['username'], 
-            'name' => array_get($user, 'display_name'),
-            'email' => array_get($user, 'email'), 
+            'id' => $user['uuid'], 'nickname' => $user['username'], 
+            'name' => array_get($user, 'display_name'), 'email' => array_get($user, 'email'), 
             'avatar' => array_get($user, 'links.avatar.href'),
         ]);
     }
@@ -115,9 +113,7 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
     protected function getTokenFields($code)
     {
         return [
-            'code' => $code, 
-            'redirect_uri' => $this->redirectUrl,
-            'grant_type' => 'authorization_code'
+            'code' => $code, 'redirect_uri' => $this->redirectUrl, 'grant_type' => 'authorization_code'
         ];
     }
 }

--- a/src/Two/BitbucketProvider.php
+++ b/src/Two/BitbucketProvider.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Laravel\Socialite\Two;
+
+use Exception;
+use GuzzleHttp\ClientInterface;
+
+class BitbucketProvider extends AbstractProvider implements ProviderInterface
+{
+    /**
+     * The scopes being requested.
+     *
+     * @var array
+     */
+    protected $scopes = ['email'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://bitbucket.org/site/oauth2/authorize', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://bitbucket.org/site/oauth2/access_token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $userUrl = 'https://api.bitbucket.org/2.0/user?access_token='.$token;
+
+        $response = $this->getHttpClient()->get($userUrl);
+
+        $user = json_decode($response->getBody(), true);
+
+        if (in_array('email', $this->scopes)) {
+            $user['email'] = $this->getEmailByToken($token);
+        }
+
+        return $user;
+    }
+
+    /**
+     * Get the email for the given access token.
+     *
+     * @param  string  $token
+     * @return string|null
+     */
+    protected function getEmailByToken($token)
+    {
+        $emailsUrl = 'https://api.bitbucket.org/2.0/user/emails?access_token='.$token;
+
+        try {
+            $response = $this->getHttpClient()->get($emailsUrl);
+        } catch (Exception $e) {
+            return;
+        }
+
+        $emails = json_decode($response->getBody(), true);
+
+        foreach ($emails['values'] as $email) {
+            if ($email['type'] == 'email' && $email['is_primary'] && $email['is_confirmed']) {
+                return $email['email'];
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id' => $user['uuid'], 
+            'nickname' => $user['username'], 
+            'name' => array_get($user, 'display_name'),
+            'email' => array_get($user, 'email'), 
+            'avatar' => array_get($user, 'links.avatar.href'),
+        ]);
+    }
+
+    /**
+     * Get the access token for the given code.
+     *
+     * @param  string  $code
+     * @return string
+     */
+    public function getAccessToken($code)
+    {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
+            'auth' => [$this->clientId, $this->clientSecret],
+            'headers' => ['Accept' => 'application/json'],
+            $postKey => $this->getTokenFields($code),
+        ]);
+
+        return $this->parseAccessToken($response->getBody());
+    }
+
+    /**
+     * Get the POST fields for the token request.
+     *
+     * @param  string  $code
+     * @return array
+     */
+    protected function getTokenFields($code)
+    {
+        return [
+            'code' => $code, 
+            'redirect_uri' => $this->redirectUrl,
+            'grant_type' => 'authorization_code'
+        ];
+    }
+}


### PR DESCRIPTION
# Bitbucket OAuth2

On July 30, 2015 Bitbucked introduced OAuth2 - [Blog Record](https://blog.bitbucket.org/2015/07/30/bitbucket-now-supports-oauth2-and-fine-grained-scopes-for-resources/).

With OAuth2 you get access to user email and fine-grained scopes.