### PR TITLE
Added OpenID scope

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -19,6 +19,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      * @var array
      */
     protected $scopes = [
+        'openid',
         'profile',
         'email',
     ];


### PR DESCRIPTION
Without the `openid` scope, the name of the user isn't returned when G+ is disabled (for Google Apps) or the user isn't registered