### PR TITLE
Switch from pull() to get()

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -209,7 +209,7 @@ abstract class AbstractProvider implements ProviderContract
             return false;
         }
 
-        $state = $this->request->getSession()->pull('state');
+        $state = $this->request->getSession()->get('state');
 
         return ! (strlen($state) > 0 && $this->request->input('state') === $state);
     }


### PR DESCRIPTION
`$this->request->getSession()` seems to be returning `Symfony\Component\HttpFoundation\Session` for us (not `\Illuminate\Session\Store`), which provides no `pull()` method.

Changing this has stopped us from getting the error: "Call to undefined method Symfony\Component\HttpFoundation\Session\Session::pull()", from `vendor/laravel/socialite/src/Two/AbstractProvider.php:212`.