### PR TITLE
Added Bitbucket as an OAuth2 provider

### DIFF
--- a/src/One/BitbucketProvider.php
+++ b/src/One/BitbucketProvider.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Laravel\Socialite\One;
-
-class BitbucketProvider extends AbstractProvider
-{
-    //
-}

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -5,9 +5,7 @@ namespace Laravel\Socialite;
 use InvalidArgumentException;
 use Illuminate\Support\Manager;
 use Laravel\Socialite\One\TwitterProvider;
-use Laravel\Socialite\One\BitbucketProvider;
 use League\OAuth1\Client\Server\Twitter as TwitterServer;
-use League\OAuth1\Client\Server\Bitbucket as BitbucketServer;
 
 class SocialiteManager extends Manager implements Contracts\Factory
 {
@@ -116,8 +114,8 @@ class SocialiteManager extends Manager implements Contracts\Factory
     {
         $config = $this->app['config']['services.bitbucket'];
 
-        return new BitbucketProvider(
-            $this->app['request'], new BitbucketServer($this->formatConfig($config))
+        return $this->buildProvider(
+            'Laravel\Socialite\Two\BitbucketProvider', $config
         );
     }
 

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -279,7 +279,7 @@ abstract class AbstractProvider implements ProviderContract
 
         return $this;
     }
-	
+
     /**
      * Get the current scopes.
      *

--- a/src/Two/BitbucketProvider.php
+++ b/src/Two/BitbucketProvider.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Laravel\Socialite\Two;
+
+use Exception;
+
+class BitbucketProvider extends AbstractProvider implements ProviderInterface
+{
+    /**
+     * The scopes being requested.
+     *
+     * @var array
+     */
+    protected $scopes = ['email'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://bitbucket.org/site/oauth2/authorize', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://bitbucket.org/site/oauth2/access_token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $userUrl = 'https://bitbucket.org/api/1.0/user/?access_token='.$token;
+
+        $response = $this->getHttpClient()->get(
+            $userUrl, $this->getRequestOptions()
+        );
+
+        $user = json_decode($response->getBody(), true);
+
+        // Fetch uuid from 2.0 API
+        $userUrl = 'https://api.bitbucket.org/2.0/users/'.array_get($user,'user.username').'?access_token='.$token;
+        $response = $this->getHttpClient()->get(
+            $userUrl, $this->getRequestOptions()
+        );
+
+        $additionalUserData = json_decode($response->getBody(), true);
+
+        $user['id'] = array_get($additionalUserData,'uuid');
+
+        if (in_array('email', $this->scopes)) {
+            $user['email'] = $this->getEmailByUsernameAndToken(array_get($user,'user.username'),$token);
+        }
+
+        return $user;
+    }
+
+    /**
+     * Get the email for the given access token.
+     *
+     * @param  string $username
+     * @param  string $token
+     * @return null|string
+     */
+    protected function getEmailByUsernameAndToken($username, $token)
+    {
+        $emailsUrl = 'https://bitbucket.org/api/1.0/users/'.$username.'/emails?access_token='.$token;
+
+        try {
+            $response = $this->getHttpClient()->get(
+                $emailsUrl, $this->getRequestOptions()
+            );
+        } catch (Exception $e) {
+            return;
+        }
+
+        foreach (json_decode($response->getBody(), true) as $email) {
+            if ($email['primary'] && $email['active']) {
+                return $email['email'];
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id' => $user['id'], 'nickname' => array_get($user, 'user.username'), 'name' => array_get($user, 'user.display_name'),
+            'email' => $user['email'] , 'avatar' => array_get($user, 'user.avatar')
+        ]);
+    }
+
+    /**
+     * Get the POST fields for the token request.
+     *
+     * @param  string  $code
+     * @return array
+     */
+    protected function getTokenFields($code)
+    {
+        return array_add(
+            parent::getTokenFields($code), 'grant_type', 'authorization_code'
+        );
+    }
+
+    /**
+     * Get the default options for an HTTP request.
+     *
+     * @return array
+     */
+    protected function getRequestOptions()
+    {
+        return [];
+    }
+}

--- a/src/Two/BitbucketProvider.php
+++ b/src/Two/BitbucketProvider.php
@@ -43,17 +43,17 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
         $user = json_decode($response->getBody(), true);
 
         // Fetch uuid from 2.0 API
-        $userUrl = 'https://api.bitbucket.org/2.0/users/'.array_get($user,'user.username').'?access_token='.$token;
+        $userUrl = 'https://api.bitbucket.org/2.0/users/'.array_get($user, 'user.username').'?access_token='.$token;
         $response = $this->getHttpClient()->get(
             $userUrl, $this->getRequestOptions()
         );
 
         $additionalUserData = json_decode($response->getBody(), true);
 
-        $user['id'] = array_get($additionalUserData,'uuid');
+        $user['id'] = array_get($additionalUserData, 'uuid');
 
         if (in_array('email', $this->scopes)) {
-            $user['email'] = $this->getEmailByUsernameAndToken(array_get($user,'user.username'),$token);
+            $user['email'] = $this->getEmailByUsernameAndToken(array_get($user, 'user.username'), $token);
         }
 
         return $user;
@@ -92,7 +92,7 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
     {
         return (new User)->setRaw($user)->map([
             'id' => $user['id'], 'nickname' => array_get($user, 'user.username'), 'name' => array_get($user, 'user.display_name'),
-            'email' => $user['email'] , 'avatar' => array_get($user, 'user.avatar')
+            'email' => $user['email'] , 'avatar' => array_get($user, 'user.avatar'),
         ]);
     }
 


### PR DESCRIPTION
The current implementation only uses the OAuth 1 provider which is lacking important information like the UUID. 

Also the OAuth 2 token allows you to clone bitbucket repositories, while this is not possible with the OAuth 1 token.