### PR TITLE
Update BitbucketProvider to OAuth2

### DIFF
--- a/src/One/BitbucketProvider.php
+++ b/src/One/BitbucketProvider.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Laravel\Socialite\One;
-
-class BitbucketProvider extends AbstractProvider
-{
-    //
-}

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -5,9 +5,7 @@ namespace Laravel\Socialite;
 use InvalidArgumentException;
 use Illuminate\Support\Manager;
 use Laravel\Socialite\One\TwitterProvider;
-use Laravel\Socialite\One\BitbucketProvider;
 use League\OAuth1\Client\Server\Twitter as TwitterServer;
-use League\OAuth1\Client\Server\Bitbucket as BitbucketServer;
 
 class SocialiteManager extends Manager implements Contracts\Factory
 {
@@ -116,8 +114,9 @@ class SocialiteManager extends Manager implements Contracts\Factory
     {
         $config = $this->app['config']['services.bitbucket'];
 
-        return new BitbucketProvider(
-            $this->app['request'], new BitbucketServer($this->formatConfig($config))
+        return $this->buildProvider(
+            'Laravel\Socialite\Two\BitbucketProvider',
+            $config
         );
     }
 

--- a/src/Two/BitbucketProvider.php
+++ b/src/Two/BitbucketProvider.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Laravel\Socialite\Two;
+
+class BitbucketProvider extends AbstractProvider implements ProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://bitbucket.org/site/oauth2/authorize', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://bitbucket.org/site/oauth2/access_token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get('https://api.bitbucket.org/2.0/user', [
+            'headers' => [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer '.$token,
+            ],
+        ]);
+
+        $user = json_decode($response->getBody(), true);
+        $user['email'] = $this->getEmailByToken($token);
+
+        return $user;
+    }
+
+    /**
+     * Get the email for the given access token.
+     *
+     * @param  string  $token
+     * @return string|null
+     */
+    protected function getEmailByToken($token)
+    {
+        $response = $this->getHttpClient()->get('https://api.bitbucket.org/2.0/user/emails', [
+            'headers' => [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer '.$token,
+            ],
+        ]);
+
+        $response = json_decode($response->getBody(), true);
+
+        foreach ($response['values'] as $email) {
+            if ($email['is_primary'] && $email['is_confirmed']) {
+                return $email['email'];
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id' => $user['uuid'], 'nickname' => $user['username'], 'name' => array_get($user, 'display_name'),
+            'email' => array_get($user, 'email'), 'avatar' => array_get($user, 'links.avatar.href'),
+        ]);
+    }
+
+    /**
+     * Get the POST fields for the token request.
+     *
+     * @param  string  $code
+     * @return array
+     */
+    protected function getTokenFields($code)
+    {
+        return array_add(
+            parent::getTokenFields($code),
+            'grant_type',
+            'authorization_code'
+        );
+    }
+
+    /**
+     * Get the GET parameters for the code request.
+     *
+     * @param  string|null  $state
+     * @return array
+     */
+    protected function getCodeFields($state = null)
+    {
+        $fields = parent::getCodeFields($state);
+
+        // bitbucket does not currently support the scope parameter
+        unset($fields['scope']);
+
+        return $fields;
+    }
+}


### PR DESCRIPTION
The OAuth1 `BitbucketProvider` did not return `email` and required an HMAC signed `Authorization` header on subsequent API calls. It was quicker to update the provider to OAuth2 than develop for OAuth1.

Note, for the `user` data to be populated, the consumer must request at least *Account Read* permission.