### PR TITLE
Allow named routes to be used for callbacks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "league/oauth1-client": "~1.0"
     },
     "require-dev": {
+        "illuminate/routing":"~5.0",
         "mockery/mockery": "~0.9",
         "phpunit/phpunit": "~4.0"
     },

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -15,7 +15,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
     protected $uriResolver;
 
     /**
-     * Create a new SocialiteManager instance
+     * Create a new SocialiteManager instance.
      *
      * @param \Illuminate\Foundation\Application $app
      */
@@ -122,7 +122,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
     }
 
     /**
-     * Generate a URL from the provided redirect URI
+     * Generate a URL from the provided redirect URI.
      *
      * @param string $redirectUri
      * @return string

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -10,6 +10,22 @@ use League\OAuth1\Client\Server\Twitter as TwitterServer;
 class SocialiteManager extends Manager implements Contracts\Factory
 {
     /**
+     * @var \Laravel\Socialite\UriResolver
+     */
+    protected $uriResolver;
+
+    /**
+     * Create a new SocialiteManager instance
+     *
+     * @param \Illuminate\Foundation\Application $app
+     */
+    public function __construct(\Illuminate\Foundation\Application $app)
+    {
+        parent::__construct($app);
+        $this->uriResolver = new UriResolver($app['url']);
+    }
+
+    /**
      * Get a driver instance.
      *
      * @param  string  $driver
@@ -101,8 +117,19 @@ class SocialiteManager extends Manager implements Contracts\Factory
     {
         return new $provider(
             $this->app['request'], $config['client_id'],
-            $config['client_secret'], $config['redirect']
+            $config['client_secret'], $this->resolveRedirectUri($config['redirect'])
         );
+    }
+
+    /**
+     * Generate a URL from the provided redirect URI
+     *
+     * @param string $redirectUri
+     * @return string
+     */
+    protected function resolveRedirectUri($redirectUri)
+    {
+        return $this->uriResolver->resolve($redirectUri);
     }
 
     /**
@@ -130,7 +157,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
         return array_merge([
             'identifier' => $config['client_id'],
             'secret' => $config['client_secret'],
-            'callback_uri' => $config['redirect'],
+            'callback_uri' => $this->resolveRedirectUri($config['redirect']),
         ], $config);
     }
 

--- a/src/UriResolver.php
+++ b/src/UriResolver.php
@@ -1,0 +1,34 @@
+<?php namespace Laravel\Socialite;
+
+use InvalidArgumentException;
+use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
+
+class UriResolver
+{
+    /**
+     * @var \Illuminate\Contracts\Routing\UrlGeneratorContract;
+     */
+    protected $urlGenerator;
+
+    /**
+     * Create a new Uri Resolver instance.
+     *
+     * @param UrlGeneratorContract $urlGenerator
+     * @return void
+     */
+    public function __construct(UrlGeneratorContract $urlGenerator)
+    {
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function resolve($redirectUri)
+    {
+        try {
+            return $this->urlGenerator->route($redirectUri, [], true);
+        } catch(InvalidArgumentException $e) {
+            // No route with the provided name exists.
+            // We will pass the redirect uri to UrlGenerator.
+            return $this->urlGenerator->to($redirectUri);
+        }
+    }
+}

--- a/src/UriResolver.php
+++ b/src/UriResolver.php
@@ -1,4 +1,6 @@
-<?php namespace Laravel\Socialite;
+<?php
+
+namespace Laravel\Socialite;
 
 use InvalidArgumentException;
 use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
@@ -25,7 +27,7 @@ class UriResolver
     {
         try {
             return $this->urlGenerator->route($redirectUri, [], true);
-        } catch(InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             // No route with the provided name exists.
             // We will pass the redirect uri to UrlGenerator.
             return $this->urlGenerator->to($redirectUri);

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -1,19 +1,19 @@
 <?php
 
-use Mockery as m;
 use Laravel\Socialite\UriResolver;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Routing\RouteCollection;
 
-class UriResolverTest extends PHPUnit_Framework_TestCase {
+class UriResolverTest extends PHPUnit_Framework_TestCase
+{
 
     public function testProperUrlIsGeneratedWhenNamedRouteIsPresent()
     {
         $uriResolver = $this->generateUrlResolver([
-            new Route(['GET'],'/callback',['as' => 'named:callback']),
-            new Route(['GET'],'/other_callback',['as' => 'named:other_callback']),
+            new Route(['GET'], '/callback', ['as' => 'named:callback']),
+            new Route(['GET'], '/other_callback', ['as' => 'named:other_callback']),
         ]);
 
         $this->assertEquals('http://www.foo.com/callback', $uriResolver->resolve('named:callback'));
@@ -22,8 +22,8 @@ class UriResolverTest extends PHPUnit_Framework_TestCase {
     public function testProperUrlIsGeneratedWhenUrlIsPassed()
     {
         $uriResolver = $this->generateUrlResolver([
-            new Route(['GET'],'/callback',['as' => 'named:callback']),
-            new Route(['GET'],'/other_callback',['as' => 'named:other_callback']),
+            new Route(['GET'], '/callback', ['as' => 'named:callback']),
+            new Route(['GET'], '/other_callback', ['as' => 'named:other_callback']),
         ]);
 
         $this->assertEquals('http://www.no-foo.com/callback', $uriResolver->resolve('http://www.no-foo.com/callback'));
@@ -32,8 +32,8 @@ class UriResolverTest extends PHPUnit_Framework_TestCase {
     public function testProperUrlIsGeneratedWhenPathIsPassed()
     {
         $uriResolver = $this->generateUrlResolver([
-            new Route(['GET'],'/callback',[]),
-            new Route(['GET'],'/other_callback',[])
+            new Route(['GET'], '/callback', []),
+            new Route(['GET'], '/other_callback', [])
         ]);
 
         $this->assertEquals('http://www.foo.com/callback', $uriResolver->resolve('callback'));
@@ -43,12 +43,12 @@ class UriResolverTest extends PHPUnit_Framework_TestCase {
 
     protected function generateUrlResolver(array $routes, Request $request = null)
     {
-        if($request == null) {
+        if ($request == null) {
             $request = Request::create('http://www.foo.com');
         }
 
         $routeCollection = new RouteCollection();
-        foreach($routes as $route) {
+        foreach ($routes as $route) {
             $routeCollection->add($route);
         }
 

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -33,7 +33,7 @@ class UriResolverTest extends PHPUnit_Framework_TestCase
     {
         $uriResolver = $this->generateUrlResolver([
             new Route(['GET'], '/callback', []),
-            new Route(['GET'], '/other_callback', [])
+            new Route(['GET'], '/other_callback', []),
         ]);
 
         $this->assertEquals('http://www.foo.com/callback', $uriResolver->resolve('callback'));

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -8,7 +8,6 @@ use Illuminate\Routing\RouteCollection;
 
 class UriResolverTest extends PHPUnit_Framework_TestCase
 {
-
     public function testProperUrlIsGeneratedWhenNamedRouteIsPresent()
     {
         $uriResolver = $this->generateUrlResolver([
@@ -38,7 +37,6 @@ class UriResolverTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('http://www.foo.com/callback', $uriResolver->resolve('callback'));
         $this->assertEquals('http://www.foo.com/absent_callback', $uriResolver->resolve('absent_callback'));
-
     }
 
     protected function generateUrlResolver(array $routes, Request $request = null)

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Mockery as m;
+use Laravel\Socialite\UriResolver;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Routing\UrlGenerator;
+use Illuminate\Routing\RouteCollection;
+
+class UriResolverTest extends PHPUnit_Framework_TestCase {
+
+    public function testProperUrlIsGeneratedWhenNamedRouteIsPresent()
+    {
+        $uriResolver = $this->generateUrlResolver([
+            new Route(['GET'],'/callback',['as' => 'named:callback']),
+            new Route(['GET'],'/other_callback',['as' => 'named:other_callback']),
+        ]);
+
+        $this->assertEquals('http://www.foo.com/callback', $uriResolver->resolve('named:callback'));
+    }
+
+    public function testProperUrlIsGeneratedWhenUrlIsPassed()
+    {
+        $uriResolver = $this->generateUrlResolver([
+            new Route(['GET'],'/callback',['as' => 'named:callback']),
+            new Route(['GET'],'/other_callback',['as' => 'named:other_callback']),
+        ]);
+
+        $this->assertEquals('http://www.no-foo.com/callback', $uriResolver->resolve('http://www.no-foo.com/callback'));
+    }
+
+    public function testProperUrlIsGeneratedWhenPathIsPassed()
+    {
+        $uriResolver = $this->generateUrlResolver([
+            new Route(['GET'],'/callback',[]),
+            new Route(['GET'],'/other_callback',[])
+        ]);
+
+        $this->assertEquals('http://www.foo.com/callback', $uriResolver->resolve('callback'));
+        $this->assertEquals('http://www.foo.com/absent_callback', $uriResolver->resolve('absent_callback'));
+
+    }
+
+    protected function generateUrlResolver(array $routes, Request $request = null)
+    {
+        if($request == null) {
+            $request = Request::create('http://www.foo.com');
+        }
+
+        $routeCollection = new RouteCollection();
+        foreach($routes as $route) {
+            $routeCollection->add($route);
+        }
+
+        return new UriResolver(new UrlGenerator($routeCollection, $request));
+    }
+}


### PR DESCRIPTION
The callbacks were restricted to fully-qualified URLs before this. This means for an app to generate proper redirect URLs, it would be dependent upon using some env variable to determine the correct base URL.

This PR introduces `UriResolver` which allows mapping of named routes and paths for redirect URLs.