### PR TITLE
Fixed some DocBlocks that had missing sections and wrong types.

### DIFF
--- a/src/One/AbstractProvider.php
+++ b/src/One/AbstractProvider.php
@@ -40,7 +40,7 @@ abstract class AbstractProvider implements ProviderContract
     /**
      * Redirect the user to the authentication page for the provider.
      *
-     * @return RedirectResponse
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
     public function redirect()
     {
@@ -54,6 +54,7 @@ abstract class AbstractProvider implements ProviderContract
     /**
      * Get the User instance for the authenticated user.
      *
+     * @throws \InvalidArgumentException
      * @return \Laravel\Socialite\One\User
      */
     public function user()

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -124,7 +124,7 @@ abstract class AbstractProvider implements ProviderContract
     /**
      * Redirect the user of the application to the provider's authentication screen.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
     public function redirect()
     {


### PR DESCRIPTION
These are just tweaks in the DocBlocks, not highly important. 

I got myself confused when I received a "\Symfony\Component\HttpFoundation\RedirectResponse" instead of "\Illuminate\Http\RedirectResponse" from the GoogleProvider::redirect() method. Actually that was right... only the DocBlock was wrong.