### PR TITLE
Add ability to get basic social user details from an already known access_token

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -199,6 +199,19 @@ abstract class AbstractProvider implements ProviderContract
     }
 
     /**
+     * Get a Social User instance from a known access token.
+     * Oauth 2 only.
+     *
+     * @param $access_token
+     * @return \Laravel\Socialite\Two\User
+     */
+    public function userFromToken($access_token)
+    {
+        $user = $this->mapUserToObject($this->getUserByToken($access_token));
+        return $user->setToken($access_token);
+    }
+
+    /**
      * Determine if the current request / session has a mismatching "state".
      *
      * @return bool


### PR DESCRIPTION
Use case: when authenticating on a client, and wishing to verify access_token on the server, by passing access_token to server.

Many people have this issue, and it can easily be solved:

http://stackoverflow.com/questions/30543991/laravel-socialite-get-user-details-by-token
http://stackoverflow.com/questions/33088447/how-to-get-facebook-id-using-socialite-laravel-5-using-face-book-token?rq=1