### PR TITLE
Support driver with dynamic config

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -10,6 +10,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
     /**
      * Supported providers.
      *
+     * @var array
      */
     private $providers = [
 
@@ -67,9 +68,15 @@ class SocialiteManager extends Manager implements Contracts\Factory
      * @param  string  $driver
      * @param  array   $config
      * @return mixed
+     *
+     * @throws \InvalidArgumentException
      */
     public function withDynamic($driver, $config)
     {
+        if (!isset($this->providers[$driver])) {
+            throw new InvalidArgumentException("Driver [$driver] not supported.");
+        }
+
         $provider = $this->providers[$driver];
 
         if (is_array($provider)) {

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -48,6 +48,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
     public function extendProviders($providers)
     {
         $this->providers = array_merge($this->providers, $providers);
+
         return $this;
     }
 

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -73,7 +73,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     public function withDynamic($driver, $config)
     {
-        if (!isset($this->providers[$driver])) {
+        if (! isset($this->providers[$driver])) {
             throw new InvalidArgumentException("Driver [$driver] not supported.");
         }
 


### PR DESCRIPTION
That's probably an edge case, but when working with multiple websites you may want to use a driver instance with dynamic config (E.g. coming from a local database or an api call etc...), the credentials could be different for each website as well as the redirect url.

Example use is:
```php
...
$config = [
    'client_id'     => $current['client_id'],
    'client_secret' => $current['client_secret'],
    'redirect'      => 'https://' . $current['domain'] . '/your-callback-url',
];
...
return Socialite::withDynamic('facebook', $config)->redirect()
```