### PR TITLE
Google token should be an array with 'access_token' and 'expires_in' params

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -81,7 +81,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
             ],
             'headers' => [
                 'Accept' => 'application/json',
-                'Authorization' => 'Bearer '.$token,
+                'Authorization' => 'Bearer '.$token['access_token'],
             ],
         ]);
 
@@ -97,5 +97,13 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
             'id' => $user['id'], 'nickname' => array_get($user, 'nickname'), 'name' => $user['displayName'],
             'email' => $user['emails'][0]['value'], 'avatar' => array_get($user, 'image')['url'],
         ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseAccessToken($body)
+    {
+        return json_decode($body, true);
     }
 }


### PR DESCRIPTION
Official Google API client requires token to be an array with `expires_in` parameter.

Without it, we're getting this exception:

```
ErrorException in Client.php line 462:
Undefined index: expires_in

in Client.php line 462
at HandleExceptions->handleError('8', 'Undefined index: expires_in', '/home/limon/www/youtube-search/vendor/google/apiclient/src/Google/Client.php', '462', array('created' => '0')) in Client.php line 462
at Google_Client->isAccessTokenExpired() in Client.php line 351
at Google_Client->authorize() in Client.php line 756
at Google_Client->execute(object(Request), 'Google_Service_YouTube_PlaylistListResponse') in Resource.php line 232
at Google_Service_Resource->call('list', array(array('part' => 'id', 'mine' => 'true')), 'Google_Service_YouTube_PlaylistListResponse') in YouTube.php line 3705
at Google_Service_YouTube_Playlists_Resource->listPlaylists('id', array('mine' => 'true')) in AuthController.php line 76
```