### PR TITLE
getBody() return a Stream, so cast it to string

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -242,7 +242,7 @@ abstract class AbstractProvider implements ProviderContract
             $postKey => $this->getTokenFields($code),
         ]);
 
-        return $this->parseAccessToken($response->getBody());
+        return $this->parseAccessToken($response->getBody()->getContents());
     }
 
     /**

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -74,7 +74,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
             'query' => $this->getTokenFields($code),
         ]);
 
-        return $this->parseAccessToken($response->getBody());
+        return $this->parseAccessToken($response->getBody()->getContents());
     }
 
     /**
@@ -100,7 +100,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
             ],
         ]);
 
-        return json_decode($response->getBody(), true);
+        return json_decode($response->getBody()->getContents(), true);
     }
 
     /**

--- a/src/Two/GithubProvider.php
+++ b/src/Two/GithubProvider.php
@@ -40,7 +40,7 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
             $userUrl, $this->getRequestOptions()
         );
 
-        $user = json_decode($response->getBody(), true);
+        $user = json_decode($response->getBody()->getContents(), true);
 
         if (in_array('user:email', $this->scopes)) {
             $user['email'] = $this->getEmailByToken($token);
@@ -67,7 +67,7 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
             return;
         }
 
-        foreach (json_decode($response->getBody(), true) as $email) {
+        foreach (json_decode($response->getBody()->getContents(), true) as $email) {
             if ($email['primary'] && $email['verified']) {
                 return $email['email'];
             }

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -54,7 +54,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
             $postKey => $this->getTokenFields($code),
         ]);
 
-        return $this->parseAccessToken($response->getBody());
+        return $this->parseAccessToken($response->getBody()->getContents());
     }
 
     /**
@@ -85,7 +85,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
             ],
         ]);
 
-        return json_decode($response->getBody(), true);
+        return json_decode($response->getBody()->getContents(), true);
     }
 
     /**

--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -65,7 +65,7 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
             ],
         ]);
 
-        return json_decode($response->getBody(), true);
+        return json_decode($response->getBody()->getContents(), true);
     }
 
     /**


### PR DESCRIPTION
Guzzle implements PSR-7. That means that it will by default store the body of a message in a Stream that uses PHP temp streams. To retrieve all the data, you can use casting operator or getContent() method.
http://stackoverflow.com/questions/30549226/guzzlehttp-how-get-the-body-of-a-response-from-guzzle-6