### PR TITLE
Expose OAuth2 refresh_token and expires_in when available

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,8 @@ $user = Socialite::driver('github')->user();
 
 // OAuth Two Providers
 $token = $user->token;
+$refreshToken = $user->refreshToken; // not always provided
+$expiresIn = $user->expiresIn;
 
 // OAuth One Providers
 $token = $user->token;

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -33,6 +33,13 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     protected $scopes = ['email'];
 
     /**
+     * The value for the HTTP Accept header to use when requesting an access token.
+     *
+     * @var string
+     */
+    protected $accessTokenAcceptHeader = '*/*';
+
+    /**
      * Display the dialog in a popup view.
      *
      * @var bool
@@ -60,31 +67,6 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     protected function getTokenUrl()
     {
         return $this->graphUrl.'/oauth/access_token';
-    }
-
-    /**
-     * Get the access token for the given code.
-     *
-     * @param  string  $code
-     * @return string
-     */
-    public function getAccessToken($code)
-    {
-        $response = $this->getHttpClient()->get($this->getTokenUrl(), [
-            'query' => $this->getTokenFields($code),
-        ]);
-
-        return $this->parseAccessToken($response->getBody());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessToken($body)
-    {
-        parse_str($body);
-
-        return $access_token;
     }
 
     /**

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -2,8 +2,6 @@
 
 namespace Laravel\Socialite\Two;
 
-use GuzzleHttp\ClientInterface;
-
 class GoogleProvider extends AbstractProvider implements ProviderInterface
 {
     /**
@@ -38,23 +36,6 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     protected function getTokenUrl()
     {
         return 'https://accounts.google.com/o/oauth2/token';
-    }
-
-    /**
-     * Get the access token for the given code.
-     *
-     * @param  string  $code
-     * @return string
-     */
-    public function getAccessToken($code)
-    {
-        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
-
-        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            $postKey => $this->getTokenFields($code),
-        ]);
-
-        return $this->parseAccessToken($response->getBody());
     }
 
     /**

--- a/src/Two/User.php
+++ b/src/Two/User.php
@@ -14,6 +14,20 @@ class User extends AbstractUser
     public $token;
 
     /**
+     * The refresh token that can be exchanged for a new access token.
+     *
+     * @var string
+     */
+    public $refreshToken;
+
+    /**
+     * The number of seconds the access token is valid for.
+     *
+     * @var int
+     */
+    public $expiresIn;
+
+    /**
      * Set the token on the user.
      *
      * @param  string  $token
@@ -22,6 +36,32 @@ class User extends AbstractUser
     public function setToken($token)
     {
         $this->token = $token;
+
+        return $this;
+    }
+
+    /**
+     * Set the refresh token required to obtain a new access token.
+     *
+     * @param  string  $refreshToken
+     * @return $this
+     */
+    public function setRefreshToken($refreshToken)
+    {
+        $this->refreshToken = $refreshToken;
+
+        return $this;
+    }
+
+    /**
+     * Set the number of seconds the access token is valid for as measured from when the access token was granted.
+     *
+     * @param  int  $expiresIn
+     * @return $this
+     */
+    public function setExpiresIn($expiresIn)
+    {
+        $this->expiresIn = $expiresIn;
 
         return $this;
     }

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -24,7 +24,18 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://auth.url', $response->getTargetUrl());
     }
 
-    public function testUserReturnsAUserInstanceForTheAuthenticatedRequest()
+    public function getMockResponses()
+    {
+        return [
+            ['application/json', '{ "access_token" : "access_token", "refresh_token" : "refresh_token", "expires_in" : 3600 }'],
+            ['application/x-www-form-urlencoded', 'access_token=access_token&refresh_token=refresh_token&expires_in=3600'],
+        ];
+    }
+
+    /**
+     * @dataProvider getMockResponses
+     */
+    public function testUserReturnsAUserInstanceForTheAuthenticatedRequest($contentType, $responseBody)
     {
         $request = Request::create('foo', 'GET', ['state' => str_repeat('A', 40), 'code' => 'code']);
         $request->setSession($session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface'));
@@ -34,11 +45,15 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
         $provider->http->shouldReceive('post')->once()->with('http://token.url', [
             'headers' => ['Accept' => 'application/json'], 'form_params' => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
         ])->andReturn($response = m::mock('StdClass'));
-        $response->shouldReceive('getBody')->once()->andReturn('access_token=access_token');
+        $response->shouldReceive('getHeader')->once()->with('Content-Type')->andReturn([$contentType]);
+        $response->shouldReceive('getBody')->once()->andReturn($responseBody);
         $user = $provider->user();
 
         $this->assertInstanceOf('Laravel\Socialite\Two\User', $user);
         $this->assertEquals('foo', $user->id);
+        $this->assertEquals('access_token', $user->token);
+        $this->assertEquals('refresh_token', $user->refreshToken);
+        $this->assertEquals(3600, $user->expiresIn);
     }
 
     /**

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\Http\Request;
+use GuzzleHttp\ClientInterface;
 use Laravel\Socialite\Two\User;
 use Laravel\Socialite\Two\AbstractProvider;
 
@@ -42,8 +43,9 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
         $session->shouldReceive('pull')->once()->with('state')->andReturn(str_repeat('A', 40));
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock('StdClass');
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
         $provider->http->shouldReceive('post')->once()->with('http://token.url', [
-            'headers' => ['Accept' => 'application/json'], 'form_params' => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
+            'headers' => ['Accept' => 'application/json'], $postKey => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
         ])->andReturn($response = m::mock('StdClass'));
         $response->shouldReceive('getHeader')->once()->with('Content-Type')->andReturn([$contentType]);
         $response->shouldReceive('getBody')->once()->andReturn($responseBody);


### PR DESCRIPTION
Previously the OAuth2 refresh token was inaccessible. This PR exposes it in the User object when it is returned by the provider. I've regression tested this change with each of the supported OAuth2 providers: Google, Facebook, GitHub and LinkedIn.

Note: [Google only includes the refresh_token on the first authorization](http://stackoverflow.com/a/10857806/166339). To force Google to include the refresh_token every time (such as you might do while validating this PR!), you can pass a couple of additional parameters as shown below.

```php
public function redirectToGoogle() {
    return Socialite::with('google')
            ->scopes(['profile', 'email'])
            ->with(['access_type' => 'offline', 'approval_prompt' => 'force'])
            ->redirect();
}
```