### PR TITLE
Expose OAuth2 refresh_token and expires_in when available (refactored)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,8 @@ $user = Socialite::driver('github')->user();
 
 // OAuth Two Providers
 $token = $user->token;
+$refreshToken = $user->refreshToken; // not always provided
+$expiresIn = $user->expiresIn;
 
 // OAuth One Providers
 $token = $user->token;

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -2,8 +2,6 @@
 
 namespace Laravel\Socialite\Two;
 
-use GuzzleHttp\ClientInterface;
-
 class GoogleProvider extends AbstractProvider implements ProviderInterface
 {
     /**
@@ -38,23 +36,6 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     protected function getTokenUrl()
     {
         return 'https://accounts.google.com/o/oauth2/token';
-    }
-
-    /**
-     * Get the access token for the given code.
-     *
-     * @param  string  $code
-     * @return string
-     */
-    public function getAccessToken($code)
-    {
-        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
-
-        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            $postKey => $this->getTokenFields($code),
-        ]);
-
-        return $this->parseAccessToken($response->getBody());
     }
 
     /**

--- a/src/Two/User.php
+++ b/src/Two/User.php
@@ -14,6 +14,20 @@ class User extends AbstractUser
     public $token;
 
     /**
+     * The refresh token that can be exchanged for a new access token.
+     *
+     * @var string
+     */
+    public $refreshToken;
+
+    /**
+     * The number of seconds the access token is valid for.
+     *
+     * @var int
+     */
+    public $expiresIn;
+
+    /**
      * Set the token on the user.
      *
      * @param  string  $token
@@ -22,6 +36,32 @@ class User extends AbstractUser
     public function setToken($token)
     {
         $this->token = $token;
+
+        return $this;
+    }
+
+    /**
+     * Set the refresh token required to obtain a new access token.
+     *
+     * @param  string  $refreshToken
+     * @return $this
+     */
+    public function setRefreshToken($refreshToken)
+    {
+        $this->refreshToken = $refreshToken;
+
+        return $this;
+    }
+
+    /**
+     * Set the number of seconds the access token is valid for as measured from when the access token was granted.
+     *
+     * @param  int  $expiresIn
+     * @return $this
+     */
+    public function setExpiresIn($expiresIn)
+    {
+        $this->expiresIn = $expiresIn;
 
         return $this;
     }


### PR DESCRIPTION
Previously the OAuth2 refresh token was inaccessible. This PR exposes it in the User object when it is returned by the provider. I've regression tested this change with each of the supported OAuth2 providers: Google, Facebook, GitHub and LinkedIn.

Note: [Google only includes the refresh_token on the first authorization](http://stackoverflow.com/a/10857806/166339). To force Google to include the refresh_token every time (such as you might do while validating this PR!), you can pass a couple of additional parameters as shown below.

```php
public function redirectToGoogle() {
    return Socialite::with('google')
            ->scopes(['profile', 'email'])
            ->with(['access_type' => 'offline', 'approval_prompt' => 'force'])
            ->redirect();
}
```
Note: This is a refactoring of PR #143 based on @taylorotwell's feedback.