### PR TITLE
Code request parameters merging

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -175,7 +175,7 @@ abstract class AbstractProvider implements ProviderContract
             $fields['state'] = $state;
         }
 
-        return array_merge($fields, $this->parameters);
+        return array_merge($this->parameters, $fields);
     }
 
     /**


### PR DESCRIPTION
Custom parameters should be overridden by required parameters of the code request.
In my situation, setting a custom parameter `state` with `with` resulted in inconsistency between states.
I was thinking about checking existed state before `Str::rand()` a new one but it makes sense to use these prepared fields.