### PR TITLE
[2.0] Change the scope of $user

### DIFF
--- a/src/AbstractUser.php
+++ b/src/AbstractUser.php
@@ -46,7 +46,7 @@ abstract class AbstractUser implements ArrayAccess, Contracts\User
      *
      * @var array
      */
-    protected $user;
+    public $user;
 
     /**
      * Get the unique identifier for the user.


### PR DESCRIPTION
Fix bug introduced in a2eb7a1386db9a152a7d9e2287498d5f461157ea and change the `$user` access for `protected` to `public`.

See https://github.com/laravel/socialite/commit/a2eb7a1386db9a152a7d9e2287498d5f461157ea#commitcomment-17645264