### PR TITLE
Return \Illuminate\Session\Store

### DIFF
--- a/src/One/AbstractProvider.php
+++ b/src/One/AbstractProvider.php
@@ -44,7 +44,7 @@ abstract class AbstractProvider implements ProviderContract
      */
     public function redirect()
     {
-        $this->request->getSession()->set(
+        $this->request->session()->set(
             'oauth.temp', $temp = $this->server->getTemporaryCredentials()
         );
 
@@ -81,7 +81,7 @@ abstract class AbstractProvider implements ProviderContract
      */
     protected function getToken()
     {
-        $temp = $this->request->getSession()->get('oauth.temp');
+        $temp = $this->request->session()->get('oauth.temp');
 
         return $this->server->getTokenCredentials(
             $temp, $this->request->get('oauth_token'), $this->request->get('oauth_verifier')

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -140,7 +140,7 @@ abstract class AbstractProvider implements ProviderContract
         $state = null;
 
         if ($this->usesState()) {
-            $this->request->getSession()->set('state', $state = Str::random(40));
+            $this->request->session()->set('state', $state = Str::random(40));
         }
 
         return new RedirectResponse($this->getAuthUrl($state));
@@ -235,7 +235,7 @@ abstract class AbstractProvider implements ProviderContract
             return false;
         }
 
-        $state = $this->request->getSession()->pull('state');
+        $state = $this->request->session()->pull('state');
 
         return ! (strlen($state) > 0 && $this->request->input('state') === $state);
     }


### PR DESCRIPTION
Return the expected `\Illuminate\Session\Store` instead of a `\Illuminate\Session\SessionInterface`
See calls to `get`, `set` and `pull`