### PR TITLE
getUserByToken app secret proof fix

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -88,9 +88,16 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $appSecretProof = hash_hmac('sha256', $token, $this->clientSecret);
+        $meUrl = $this->graphUrl.'/'.$this->version.'/me?access_token='.$token.'&fields='.implode(',', $this->fields);
 
-        $response = $this->getHttpClient()->get($this->graphUrl.'/'.$this->version.'/me?access_token='.$token.'&appsecret_proof='.$appSecretProof.'&fields='.implode(',', $this->fields), [
+        if (!empty($this->clientSecret))
+        {
+            $appSecretProof = hash_hmac('sha256', $token, $this->clientSecret);
+
+            $meUrl .= '&appsecret_proof=' . $appSecretProof;
+        }
+
+        $response = $this->getHttpClient()->get($meUrl, [
             'headers' => [
                 'Accept' => 'application/json',
             ],

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -90,7 +90,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     {
         $meUrl = $this->graphUrl.'/'.$this->version.'/me?access_token='.$token.'&fields='.implode(',', $this->fields);
 
-        if (!empty($this->clientSecret)) {
+        if (! empty($this->clientSecret)) {
             $appSecretProof = hash_hmac('sha256', $token, $this->clientSecret);
 
             $meUrl .= '&appsecret_proof='.$appSecretProof;

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -90,11 +90,10 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     {
         $meUrl = $this->graphUrl.'/'.$this->version.'/me?access_token='.$token.'&fields='.implode(',', $this->fields);
 
-        if (!empty($this->clientSecret))
-        {
+        if (!empty($this->clientSecret)) {
             $appSecretProof = hash_hmac('sha256', $token, $this->clientSecret);
 
-            $meUrl .= '&appsecret_proof=' . $appSecretProof;
+            $meUrl .= '&appsecret_proof='.$appSecretProof;
         }
 
         $response = $this->getHttpClient()->get($meUrl, [


### PR DESCRIPTION
The app secret proof parameter is now sent only if a Facebook app is
configured.

With the previous revision you can't retrieve the user without having a client secret configured.

The API raises the following error: Invalid appsecret_proof provided in the API argument.