### PR TITLE
Added Macroable trait to SocialiteManager

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -4,11 +4,14 @@ namespace Laravel\Socialite;
 
 use InvalidArgumentException;
 use Illuminate\Support\Manager;
+use Illuminate\Support\Traits\Macroable;
 use Laravel\Socialite\One\TwitterProvider;
 use League\OAuth1\Client\Server\Twitter as TwitterServer;
 
 class SocialiteManager extends Manager implements Contracts\Factory
 {
+    use Macroable;
+
     /**
      * Get a driver instance.
      *


### PR DESCRIPTION
Example use case such that a package service provider registers a routes method akin to those used by `Auth` etc.

    SocialiteManager::macro('routes', function () {
        app('router')->get('example', function() {
            return 'macroed route';
        });
    });

    Socialte::routes();