### PR TITLE
Use the public method to get the scopes

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -168,7 +168,7 @@ abstract class AbstractProvider implements ProviderContract
     {
         $fields = [
             'client_id' => $this->clientId, 'redirect_uri' => $this->redirectUrl,
-            'scope' => $this->formatScopes($this->scopes, $this->scopeSeparator),
+            'scope' => $this->formatScopes($this->getScopes(), $this->scopeSeparator),
             'response_type' => 'code',
         ];
 


### PR DESCRIPTION
There may be a scenario when a provider class can be extended and override the scopes (or add additional ones for example in case of GoogleProvider), example:

```php
<?php
use Laravel\Socialite\Two\GoogleProvider;
class YoutubeProvider extends GoogleProvider {
    public function getScopes()
    {
        return array_merge(parent::getScopes(), [
            'https://www.googleapis.com/auth/youtube.readonly'
        ]);
    }
}