### PR TITLE
Allow overriding the session state string.

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -389,12 +389,12 @@ abstract class AbstractProvider implements ProviderContract
 
         return $this;
     }
-    
+
     /**
-    * Get the string used for session state
-    *
-    * @return string
-    */
+     * Get the string used for session state
+     *
+     * @return string
+     */
     public function getState()
     {
         return Str::random(40);

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -395,7 +395,7 @@ abstract class AbstractProvider implements ProviderContract
      *
      * @return string
      */
-    public function getState()
+    protected function getState()
     {
         return Str::random(40);
     }

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -391,7 +391,7 @@ abstract class AbstractProvider implements ProviderContract
     }
 
     /**
-     * Get the string used for session state
+     * Get the string used for session state.
      *
      * @return string
      */

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -140,7 +140,7 @@ abstract class AbstractProvider implements ProviderContract
         $state = null;
 
         if ($this->usesState()) {
-            $this->request->session()->set('state', $state = Str::random(40));
+            $this->request->session()->set('state', $state = $this->getState());
         }
 
         return new RedirectResponse($this->getAuthUrl($state));
@@ -388,6 +388,16 @@ abstract class AbstractProvider implements ProviderContract
         $this->stateless = true;
 
         return $this;
+    }
+    
+    /**
+    * Get the string used for session state
+    *
+    * @return string
+    */
+    public function getState()
+    {
+        return Str::random(40);
     }
 
     /**


### PR DESCRIPTION
In some scenarios we could override the session state string with another type of encryption. For example an use case will be to store encrypted information into the session state.