### PR TITLE
add "get user profile" from `token` and `secret`

### DIFF
--- a/src/One/AbstractProvider.php
+++ b/src/One/AbstractProvider.php
@@ -4,6 +4,7 @@ namespace Laravel\Socialite\One;
 
 use Illuminate\Http\Request;
 use InvalidArgumentException;
+use League\OAuth1\Client\Credentials\TokenCredentials;
 use League\OAuth1\Client\Server\Server;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Laravel\Socialite\Contracts\Provider as ProviderContract;
@@ -67,6 +68,29 @@ abstract class AbstractProvider implements ProviderContract
 
         $instance = (new User)->setRaw($user->extra)
                 ->setToken($token->getIdentifier(), $token->getSecret());
+
+        return $instance->map([
+            'id' => $user->uid, 'nickname' => $user->nickname,
+            'name' => $user->name, 'email' => $user->email, 'avatar' => $user->imageUrl,
+        ]);
+    }
+
+    /**
+     * @param $token
+     * @param $secret
+     *
+     * @return  $this
+     */
+    public function userFromTokenAndSecret($token, $secret)
+    {
+        $tokenCredentials = new TokenCredentials();
+        $tokenCredentials->setIdentifier($token);
+        $tokenCredentials->setSecret($secret);
+
+        $user = $this->server->getUserDetails($tokenCredentials);
+
+        $instance = (new User)->setRaw($user->extra)
+            ->setToken($tokenCredentials->getIdentifier(), $tokenCredentials->getSecret());
 
         return $instance->map([
             'id' => $user->uid, 'nickname' => $user->nickname,


### PR DESCRIPTION
The `Two/AbstractProvider.php` has `userFromToken($token)` to retrieve
user profile from a `token`.

While `One/AbstractProvider.php` doesn’t have this feature, I added
`userFromTokenAndSecret($token, $secret)` to retrieve user profile from
the  `token` and `secret`. (Tested with Twitter).