### PR TITLE
Update php versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
+  - 7.0
+  - 7.1
   - hhvm
 
 sudo: false


### PR DESCRIPTION
Disable php 5.5 in .travis.yml

Problem 1
    - illuminate/contracts 5.5.x-dev requires php >=7.0 -> your PHP version (5.5.21) does not satisfy that requirement.
    - illuminate/contracts 5.4.x-dev requires php >=5.6.4 -> your PHP version (5.5.21) does not satisfy that requirement.
    - Installation request for illuminate/contracts ~5.4 -> satisfiable by illuminate/contracts[5.4.x-dev, 5.5.x-dev].
