### PR TITLE
Make use of getState method

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -140,7 +140,7 @@ abstract class AbstractProvider implements ProviderContract
         $state = null;
 
         if ($this->usesState()) {
-            $this->request->getSession()->put('state', $state = Str::random(40));
+            $this->request->getSession()->put('state', $state = $this->getState());
         }
 
         return new RedirectResponse($this->getAuthUrl($state));


### PR DESCRIPTION
The expected behaviour of `$state` was to use the `getState` method. On branch `2.0` this was already implemented, but on `3.0` something was not right and the method is not used. This fixes this issue which allows the session state to be overwritten if needed.