### PR TITLE
[3.0] Bitbucket - fix access_token parsing

### DIFF
--- a/src/Two/BitbucketProvider.php
+++ b/src/Two/BitbucketProvider.php
@@ -101,7 +101,7 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
             $postKey => $this->getTokenFields($code),
         ]);
 
-        return $this->parseAccessToken($response->getBody());
+        return json_decode($response->getBody(), true)['access_token'];
     }
 
     /**


### PR DESCRIPTION
As `parseAccessToken` function as been removed in  https://github.com/laravel/socialite/commit/713b4afd3bdc5b07f76975cf584ebcb3a68d96bf.