### PR TITLE
[3.0] Always use session().

### DIFF
--- a/src/One/AbstractProvider.php
+++ b/src/One/AbstractProvider.php
@@ -45,7 +45,7 @@ abstract class AbstractProvider implements ProviderContract
      */
     public function redirect()
     {
-        $this->request->getSession()->put(
+        $this->request->session()->put(
             'oauth.temp', $temp = $this->server->getTemporaryCredentials()
         );
 

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -140,7 +140,7 @@ abstract class AbstractProvider implements ProviderContract
         $state = null;
 
         if ($this->usesState()) {
-            $this->request->getSession()->put('state', $state = Str::random(40));
+            $this->request->session()->put('state', $state = Str::random(40));
         }
 
         return new RedirectResponse($this->getAuthUrl($state));


### PR DESCRIPTION
As `put` function is part of `\Illuminate\Session\Store`, not `\Symfony\Component\HttpFoundation\Session\SessionInterface`.