### PR TITLE
Send client fields to Bitbucket

### DIFF
--- a/src/Two/BitbucketProvider.php
+++ b/src/Two/BitbucketProvider.php
@@ -112,8 +112,6 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getTokenFields($code)
     {
-        return [
-            'code' => $code, 'redirect_uri' => $this->redirectUrl, 'grant_type' => 'authorization_code',
-        ];
+        return parent::getTokenFields($code) + ['grant_type' => 'authorization_code'];
     }
 }


### PR DESCRIPTION
These tokens are necessary for Bitbucket OAuth. Otherwise a `400 Bad Request` (*client id must be provided*) is returned.

I remember these being missing from the 2.0 release as well. Not sure if it's just me, but [Shift](https://laravelshift.com) does not work without them and they seem inline with the other providers.