### PR TITLE
[3.0] Allow PHPUnit ~6.0 in composer's dev requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "mockery/mockery": "~0.9",
-        "phpunit/phpunit": "~4.0|~5.0"
+        "phpunit/phpunit": "~4.0|~5.0|~6.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+$loader = require __DIR__.'/../vendor/autoload.php';
+
+if (! class_exists('\PHPUnit\Framework\TestCase', true)) {
+    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+} elseif (! class_exists('\PHPUnit_Framework_TestCase', true)) {
+    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
+}


### PR DESCRIPTION
Allows PHPUnit ^6.0 to be used in projects that use Laravel Socialite.

The class aliases only come into effect when executing the Socialite test suite and will not affect projects having it as a dependency.

:octocat: 
