### PR TITLE
Fixing access token parsing

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -62,7 +62,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getTokenUrl()
     {
-        return $this->graphUrl.'/oauth/access_token';
+        return $this->graphUrl.'/'.$this->version.'/oauth/access_token';
     }
 
     /**
@@ -76,9 +76,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
             $postKey => $this->getTokenFields($code),
         ]);
 
-        $data = [];
-
-        parse_str($response->getBody(), $data);
+        $data = json_decode($response->getBody(), true);
 
         return Arr::add($data, 'expires_in', Arr::pull($data, 'expires'));
     }


### PR DESCRIPTION
Specifying version when requesting access token. 

v2.2 of Facebook API (last version to use query strings here) is no longer available, starting today.

https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow

> Note: From v2.3 onward this endpoint will return a proper JSON response. If your call doesn't specify a version it will default to the oldest available version.