### PR TITLE
Change picture type to square

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -114,7 +114,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
 
         return (new User)->setRaw($user)->map([
             'id' => $user['id'], 'nickname' => null, 'name' => isset($user['name']) ? $user['name'] : null,
-            'email' => isset($user['email']) ? $user['email'] : null, 'avatar' => $avatarUrl.'?type=normal',
+            'email' => isset($user['email']) ? $user['email'] : null, 'avatar' => $avatarUrl.'?type=square',
             'avatar_original' => $avatarUrl.'?width=1920',
             'profileUrl' => isset($user['link']) ? $user['link'] : null,
         ]);


### PR DESCRIPTION
In Facebook it is possible to set a vertical or horizontal image. When using the type=normal, and setting the height and width to 32x32, the image will be squeezed. Square already returns an image width same height.