### PR TITLE
Resolved bug facebook callback

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -78,7 +78,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
 
         $data = [];
 
-       	parse_str($response->getBody(), $data);
+        parse_str($response->getBody(), $data);
         $json = json_decode(key($data), true);
 
         return Arr::add($json, 'expires_in', Arr::pull($json, 'expires'));

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -78,9 +78,10 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
 
         $data = [];
 
-        $data = json_decode($response->getBody(), true);
+       	parse_str($response->getBody(), $data);
+        $json = json_decode(key($data), true);
 
-        return Arr::add($data, 'expires_in', Arr::pull($data, 'expires'));
+        return Arr::add($json, 'expires_in', Arr::pull($json, 'expires'));
     }
 
     /**


### PR DESCRIPTION
# Issue / Motivation:
Access Token not parsed

Client error: `GET https://graph.facebook.com/v2.8/me?access_token=&fields=name,email,gender,verified,link&appsecret_proof=MYPROOF` resulted in a `400 Bad Request` response:
{"error":{"message":"An active access token must be used to query information about the current user.","type":"OAuthExce (truncated...)

## Expected behavior:
public function getAccessTokenResponse($code) needs to return the access_token from the code param
## Actual behavior:
returning empty token
## Steps to reproduce the behavior:
Just login

## Proposed solution:
In the file *vendor/laravel/socialite/src/Two/FacebookProvider.php*
Function **getAccessTokenResponse**

This line:
```
parse_str($response->getBody(), $data);
```
Return:
```
array:1 [
  "{"access_token":"EAAJSQDxnMQcBAEdXLdAskt9zfNpWzwdJCWHWqG6nWFGLiOd4lgKsl1UqvsAogBmtWENFJPZBbZARMtTqsZCjKgoCkhZAP8PvO4G7Om3Sb7gr51tcw6NfqwkeUsiDZBxDs8WOCAyitkMy2VZAAisreiZBIvEebcLxJcFRQEYaBbNJdu1BnvTHHUx","token_type":"bearer","expires_in":5183521}" => ""
]
```

If I'm doing that:

```
parse_str($response->getBody(), $data);
$json = json_decode(key($data));
dd($json);
```

```
{
  "access_token": "EAAJSQDxnMQcBAHD1X08Fko6oCoOjLrUE3JOFot6ujLj3jO0HGXamYyzs18aaW2znZBkxBvOnpsheKnGB0mIR8pCFYH38gS3OtpLPSREQ5S2xeCgjlSfVYi4I6U7i6WhkfSYbQfayci66Oh8wb6ASMZArOERYZC2u1jM5smRZCK7XXnGTN2f0",
  "token_type": "bearer",
  "expires_in": 5183429
}
```

So I need to do in order to get the facebook login to work:

```
parse_str($response->getBody(), $data);
$json = json_decode(key($data), true);
return Arr::add($json, 'expires_in', Arr::pull($json, 'expires'));
```

I'm the only one having this issue ? Did I forgot something ?