### PR TITLE
Check if the authorization code is present

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
+use InvalidArgumentException;
 use GuzzleHttp\ClientInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Laravel\Socialite\Contracts\Provider as ProviderContract;
@@ -196,6 +197,10 @@ abstract class AbstractProvider implements ProviderContract
      */
     public function user()
     {
+        if (! $this->hasNecessaryCode()) {
+            throw new InvalidArgumentException('Invalid request. Missing code parameter.');
+        }
+
         if ($this->hasInvalidState()) {
             throw new InvalidStateException;
         }
@@ -270,6 +275,16 @@ abstract class AbstractProvider implements ProviderContract
             'client_id' => $this->clientId, 'client_secret' => $this->clientSecret,
             'code' => $code, 'redirect_uri' => $this->redirectUrl,
         ];
+    }
+
+    /**
+     * Determine if the request has the necessary authorization code.
+     *
+     * @return bool
+     */
+    protected function hasNecessaryCode()
+    {
+        return $this->request->has('code');
     }
 
     /**

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -93,4 +93,16 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect');
         $provider->user();
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testExceptionIsThrownWhenAuthorizationCodeIsMissing()
+    {
+        $request = Request::create('foo');
+        $request->setLaravelSession($session = m::mock('Illuminate\Contracts\Session\Session'));
+
+        $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect');
+        $provider->user();
+    }
 }


### PR DESCRIPTION
OAuth 1 providers check if the OAuth verifier is present but OAuth 2 providers don't.

I've added the same verification for OAuth2 providers. This allows to catch all the errors about malformed requests with a simple `try…catch`:

```php
try {
    $user = Socialite::driver('any-driver')->user();
} catch (InvalidArgumentException $e) {
    // The authorization request is missing either an OAuth verifier or an authorization code.
    // This can happen when the user cancels the authentication on the remote website.
}
```

This will not break the third-party providers in the [Socialite Providers](https://socialiteproviders.github.io/) project since [they rewrote the `user` method](https://github.com/SocialiteProviders/Manager/blob/master/src/OAuth2/AbstractProvider.php#L29), so you can merge with confidence.

However, once this pull request will be merged, I will make a new pull request to the [Socialite Providers](https://socialiteproviders.github.io/) project so they handle this verification too.