### PR TITLE
Remove redundant code

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Socialite\Two;
 
-use Illuminate\Support\Arr;
 use GuzzleHttp\ClientInterface;
 
 class FacebookProvider extends AbstractProvider implements ProviderInterface

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -76,11 +76,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
             $postKey => $this->getTokenFields($code),
         ]);
 
-        $data = [];
-
-        $data = json_decode($response->getBody(), true);
-
-        return Arr::add($data, 'expires_in', Arr::pull($data, 'expires'));
+        return json_decode($response->getBody(), true);
     }
 
     /**

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -60,7 +60,7 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
         $provider->http->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.8/oauth/access_token', [
             $postKey => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
         ])->andReturn($response = m::mock('StdClass'));
-        $response->shouldReceive('getBody')->once()->andReturn(json_encode(['access_token' => 'access_token', 'expires' => 5183085]));
+        $response->shouldReceive('getBody')->once()->andReturn(json_encode(['access_token' => 'access_token', 'expires_in' => 5183085]));
         $user = $provider->user();
 
         $this->assertInstanceOf('Laravel\Socialite\Two\User', $user);


### PR DESCRIPTION
Initializing a `$data` variable was redundant when the JSON was assigned to it in the next LOC; and the timestamp now comes back under the `expires_at` key, so no need to alias `expires` to `expires_at` any more.