### PR TITLE
Bump Graph API version to v2.9

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -19,7 +19,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      *
      * @var string
      */
-    protected $version = 'v2.8';
+    protected $version = 'v2.9';
 
     /**
      * The user fields being requested.


### PR DESCRIPTION
[Graph v2.9](https://developers.facebook.com/blog/post/2017/04/18/graph-api-v2.9/) is a thing now. :)