### PR TITLE
Bump Graph API version to 2.9

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -19,7 +19,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      *
      * @var string
      */
-    protected $version = 'v2.8';
+    protected $version = 'v2.9';
 
     /**
      * The user fields being requested.

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -57,7 +57,7 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
         $provider = new FacebookTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock('StdClass');
         $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
-        $provider->http->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.8/oauth/access_token', [
+        $provider->http->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.9/oauth/access_token', [
             $postKey => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
         ])->andReturn($response = m::mock('StdClass'));
         $response->shouldReceive('getBody')->once()->andReturn(json_encode(['access_token' => 'access_token', 'expires' => 5183085]));


### PR DESCRIPTION
version bump: [Graph API version 2.9](https://developers.facebook.com/blog/post/2017/04/18/graph-api-v2.9/)