### PR TITLE
Add setScopes method and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,11 @@ The `redirect` method takes care of sending the user to the OAuth provider, whil
 ```php
 return Socialite::driver('github')
             ->scopes(['scope1', 'scope2'])->redirect();
+```
 
-// You can also overwrite all exisiting scopes using setScopes
+You can overwrite all exisiting scopes using the `setScopes` method:
+
+```php
 return Socialite::driver('github')
             ->setScopes(['scope1', 'scope2'])->redirect();
 ```

--- a/README.md
+++ b/README.md
@@ -90,11 +90,15 @@ class LoginController extends Controller
 }
 ```
 
-The `redirect` method takes care of sending the user to the OAuth provider, while the `user` method will read the incoming request and retrieve the user's information from the provider. Before redirecting the user, you may also set "scopes" on the request using the `scopes` method. This method will overwrite all existing scopes:
+The `redirect` method takes care of sending the user to the OAuth provider, while the `user` method will read the incoming request and retrieve the user's information from the provider. Before redirecting the user, you may also add additional "scopes" on the request using the `scopes` method. This method will merge all existing scopes with the ones you supply:
 
 ```php
 return Socialite::driver('github')
             ->scopes(['scope1', 'scope2'])->redirect();
+
+// You can also overwrite all exisiting scopes using setScopes
+return Socialite::driver('github')
+            ->setScopes(['scope1', 'scope2'])->redirect();
 ```
 
 Of course, you will need to define routes to your controller methods:

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -283,7 +283,7 @@ abstract class AbstractProvider implements ProviderContract
     }
 
     /**
-     * Set the scopes of the requested access.
+     * Merge the scopes of the requested access.
      *
      * @param  array  $scopes
      * @return $this
@@ -291,6 +291,19 @@ abstract class AbstractProvider implements ProviderContract
     public function scopes(array $scopes)
     {
         $this->scopes = array_unique(array_merge($this->scopes, $scopes));
+
+        return $this;
+    }
+
+    /**
+     * Set the scopes of the requested access.
+     *
+     * @param  array  $scopes
+     * @return $this
+     */
+    public function setScopes(array $scopes)
+    {
+        $this->scopes = $scopes;
 
         return $this;
     }


### PR DESCRIPTION
Ran into an issue where the Stripe provider has a scope set by default ('read_write') which i need to replace with a different scope.

The documentation states that the `scopes` method will overwrite the existing scopes, however it actually just merges the ones supplied with the existing scopes.

I've updated the documentation for `scopes` to state that it merges the supplied scopes with the existing ones, and added a new method `setScopes` to completely overwrite the existing scopes.