### PR TITLE
Using the value helper so a closure can be provided

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -106,7 +106,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
     {
         return new $provider(
             $this->app['request'], $config['client_id'],
-            $config['client_secret'], $config['redirect']
+            $config['client_secret'], value($config['redirect'])
         );
     }
 
@@ -135,7 +135,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
         return array_merge([
             'identifier' => $config['client_id'],
             'secret' => $config['client_secret'],
-            'callback_uri' => $config['redirect'],
+            'callback_uri' => value($config['redirect']),
         ], $config);
     }
 


### PR DESCRIPTION
As I read in PR #121, there shouldn't be extra dependencies added to the socialite packages. But it become very handy to generate an url automatically by route name in a multi domain / stages setup. So I've added the `value` helper so you can call any "route generation" method within a closure;

```php
'google' => [
        'client_id' => env('GOOGLE_CLIENT_ID'),
        'client_secret' => env('GOOGLE_CLIENT_SECRET'),
        'redirect' => function () {
                return route('name_of_the_callback_route');
        }
],
```

Hopefully you'll like the idea!