### PR TITLE
Allow setting custom Guzzle request options

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -3,6 +3,7 @@
 namespace Laravel\Socialite;
 
 use InvalidArgumentException;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Manager;
 use Laravel\Socialite\Two\GithubProvider;
 use Laravel\Socialite\Two\GoogleProvider;
@@ -106,7 +107,8 @@ class SocialiteManager extends Manager implements Contracts\Factory
     {
         return new $provider(
             $this->app['request'], $config['client_id'],
-            $config['client_secret'], value($config['redirect'])
+            $config['client_secret'], value($config['redirect']),
+            Arr::get($config, 'guzzle', [])
         );
     }
 

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Socialite;
 
-use InvalidArgumentException;
 use Illuminate\Support\Arr;
+use InvalidArgumentException;
 use Illuminate\Support\Manager;
 use Laravel\Socialite\Two\GithubProvider;
 use Laravel\Socialite\Two\GoogleProvider;

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -99,7 +99,7 @@ abstract class AbstractProvider implements ProviderContract
      * @param  array   $guzzleConfig
      * @return void
      */
-    public function __construct(Request $request, $clientId, $clientSecret, $redirectUrl, $guzzleConfig)
+    public function __construct(Request $request, $clientId, $clientSecret, $redirectUrl, $guzzleConfig = [])
     {
         $this->request = $request;
         $this->clientId = $clientId;

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -83,7 +83,7 @@ abstract class AbstractProvider implements ProviderContract
     protected $stateless = false;
 
     /**
-     * Set custom Guzzle config options
+     * Set custom Guzzle config options.
      *
      * @var bool
      */

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -83,20 +83,29 @@ abstract class AbstractProvider implements ProviderContract
     protected $stateless = false;
 
     /**
+     * Set custom Guzzle config options
+     *
+     * @var bool
+     */
+    protected $guzzleConfig = [];
+
+    /**
      * Create a new provider instance.
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  string  $clientId
      * @param  string  $clientSecret
      * @param  string  $redirectUrl
+     * @param  array   $guzzleConfig
      * @return void
      */
-    public function __construct(Request $request, $clientId, $clientSecret, $redirectUrl)
+    public function __construct(Request $request, $clientId, $clientSecret, $redirectUrl, $guzzleConfig)
     {
         $this->request = $request;
         $this->clientId = $clientId;
         $this->redirectUrl = $redirectUrl;
         $this->clientSecret = $clientSecret;
+        $this->guzzleConfig = $guzzleConfig;
     }
 
     /**
@@ -339,7 +348,7 @@ abstract class AbstractProvider implements ProviderContract
     protected function getHttpClient()
     {
         if (is_null($this->httpClient)) {
-            $this->httpClient = new Client();
+            $this->httpClient = new Client($this->guzzleConfig);
         }
 
         return $this->httpClient;


### PR DESCRIPTION
This commit will allow to set custom Guzzle options in your services.php file (same as for Sparkpost, Mailgun etc).

```
'facebook' => [
        'client_id'     => env('FACEBOOK_CLIENT_ID'),
        'client_secret' => env('FACEBOOK_CLIENT_SECRET'),
        'redirect'      => env('FACEBOOK_REDIRECT'),
        'guzzle'        => [
            'expect' => false,
            'curl'   => [
                CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4,
            ],
        ]
    ]
```