### PR TITLE
Use Illuminate's RedirectResponse instead of Symfony's

### DIFF
--- a/src/One/AbstractProvider.php
+++ b/src/One/AbstractProvider.php
@@ -4,9 +4,9 @@ namespace Laravel\Socialite\One;
 
 use Illuminate\Http\Request;
 use InvalidArgumentException;
-use League\OAuth1\Client\Credentials\TokenCredentials;
+use Illuminate\Http\RedirectResponse;
 use League\OAuth1\Client\Server\Server;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use League\OAuth1\Client\Credentials\TokenCredentials;
 use Laravel\Socialite\Contracts\Provider as ProviderContract;
 
 abstract class AbstractProvider implements ProviderContract

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use GuzzleHttp\ClientInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Illuminate\Http\RedirectResponse;
 use Laravel\Socialite\Contracts\Provider as ProviderContract;
 
 abstract class AbstractProvider implements ProviderContract

--- a/tests/OAuthOneTest.php
+++ b/tests/OAuthOneTest.php
@@ -14,7 +14,7 @@ class OAuthOneTest extends PHPUnit_Framework_TestCase
         m::close();
     }
 
-    public function testRedirectGeneratesTheProperSymfonyRedirectResponse()
+    public function testRedirectGeneratesTheProperIlluminateRedirectResponse()
     {
         $server = m::mock('League\OAuth1\Client\Server\Twitter');
         $server->shouldReceive('getTemporaryCredentials')->once()->andReturn('temp');
@@ -27,6 +27,7 @@ class OAuthOneTest extends PHPUnit_Framework_TestCase
         $response = $provider->redirect();
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf('Illuminate\Http\RedirectResponse', $response);
     }
 
     public function testUserReturnsAUserInstanceForTheAuthenticatedRequest()

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -16,7 +16,7 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
         m::close();
     }
 
-    public function testRedirectGeneratesTheProperSymfonyRedirectResponse()
+    public function testRedirectGeneratesTheProperIlluminateRedirectResponse()
     {
         $request = Request::create('foo');
         $request->setLaravelSession($session = m::mock('Illuminate\Contracts\Session\Session'));
@@ -25,6 +25,7 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
         $response = $provider->redirect();
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf('Illuminate\Http\RedirectResponse', $response);
         $this->assertSame('http://auth.url', $response->getTargetUrl());
     }
 


### PR DESCRIPTION
Illuminate extends Symfony's RedirectResponse with ResponseTrait, which
introduces the `header()` method. By not using Illuminate's
RedirectResponse Socialite breaks middlewares that try to add headers to
every response (e.g. no-cache headers).