### PR TITLE
Added branch reference to composer command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ In addition to typical, form based authentication, Laravel also provides a simpl
 
 To get started with Socialite, use Composer to add the package to your project's dependencies:
 
-    composer require laravel/socialite
+    composer require laravel/socialite ^2
 
 ### Configuration
 


### PR DESCRIPTION
###the problem:
when you try to require socialite into laravel 5.3 or bellow you will have the following error:
![image](https://user-images.githubusercontent.com/5880810/28536628-9bf6357e-707e-11e7-850d-410420a12cb7.png)
###the solution:
as the 3.0 readme says: install 2.0 version, but on the 2.0 readme, the composer require command will install the version 3.0, so, i specified the ^2 version on the composer command.