### PR TITLE
Allow the callback url to be relative

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -107,7 +107,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
     {
         return new $provider(
             $this->app['request'], $config['client_id'],
-            $config['client_secret'], value($config['redirect']),
+            $config['client_secret'], $this->getRedirectUrl($config),
             Arr::get($config, 'guzzle', [])
         );
     }
@@ -137,8 +137,25 @@ class SocialiteManager extends Manager implements Contracts\Factory
         return array_merge([
             'identifier' => $config['client_id'],
             'secret' => $config['client_secret'],
-            'callback_uri' => value($config['redirect']),
+            'callback_uri' => $this->getRedirectUrl($config),
         ], $config);
+    }
+
+    /**
+     * Return the callback URL resolving a relative URI if needed.
+     *
+     * @param array $config
+     * @return string
+     */
+    protected function getRedirectUrl(array $config)
+    {
+        $redirect = value($config['redirect']);
+
+        if(Str::startsWith($redirect, '/')){
+            $redirect = url($redirect);
+        }
+
+        return $redirect;
     }
 
     /**


### PR DESCRIPTION
I needed a dynamic way to define the callback url due to all the different environments (domains) my application is deployed at. I was using an env variable for that, but I believe allowing a relative URI is more elegant. It also helps mitigate some of the headaches developers might have when the URL is hardcoded in the config.