### PR TITLE
Adding methods on facebook provider to request the long lived token

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -84,6 +84,43 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     }
 
     /**
+     * Requests the long lived access token on facebook
+     *
+     * @param  string  $accessToken
+     *
+     * @return array
+     */
+    public function getLongLivedAccessToken($accessToken)
+    {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
+            $postKey => $this->getLongLivedTokenFields($accessToken),
+        ]);
+
+        $data = [];
+
+        $data = json_decode($response->getBody(), true);
+
+        return Arr::add($data, 'expires_in', Arr::pull($data, 'expires'));
+    }
+
+    /**
+     * Get the parameters to request the long lived token
+     *
+     * @param  string  $shortLivingAccessToken
+     *
+     * @return array
+     */
+    public function getLongLivedTokenFields($shortLivingAccessToken)
+    {
+        return [
+            'client_id' => $this->clientId, 'client_secret' => $this->clientSecret,
+            'grant_type' => 'fb_exchange_token', 'fb_exchange_token' => $shortLivingAccessToken,
+        ];
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getUserByToken($token)


### PR DESCRIPTION
Added two new methods on Facebook Provider to request the long lived access token:

 * `Laravel\Socialite\Two\FacebookProvider::getLongLivedAccessToken($accessToken)`: Requests the long lived access token
 * `Laravel\Socialite\Two\FacebookProvider::getLongLivedTokenFields($shortLivingAccessToken)`: Parses the successful response of the long lived access token

Meant to be used on specific cases:
```php
<?php

...

            $facebookProvider = Socialite::driver($driver)->stateless();
            $socialUser = $facebookProvider->user();

            $response = $facebookProvider->getLongLivedAccessToken($socialUser->token);
            // $response["access_token"]
            // $response["refresh_token"]
            // $response["expires_in"]
```