### PR TITLE
[4.0] Updated to PHPUnit 6 and Mockery 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.0",
         "illuminate/contracts": "~5.4",
         "illuminate/http": "~5.4",
         "illuminate/support": "~5.4",
@@ -18,8 +18,8 @@
         "league/oauth1-client": "~1.0"
     },
     "require-dev": {
-        "mockery/mockery": "~0.9",
-        "phpunit/phpunit": "~4.0"
+        "mockery/mockery": "~1.0",
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/OAuthOneTest.php
+++ b/tests/OAuthOneTest.php
@@ -2,9 +2,10 @@
 
 use Mockery as m;
 use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
 use Laravel\Socialite\One\AbstractProvider;
 
-class OAuthOneTest extends PHPUnit_Framework_TestCase
+class OAuthOneTest extends TestCase
 {
     public function tearDown()
     {

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -3,9 +3,10 @@
 use Mockery as m;
 use Illuminate\Http\Request;
 use Laravel\Socialite\Two\User;
+use PHPUnit\Framework\TestCase;
 use Laravel\Socialite\Two\AbstractProvider;
 
-class OAuthTwoTest extends PHPUnit_Framework_TestCase
+class OAuthTwoTest extends TestCase
 {
     public function tearDown()
     {


### PR DESCRIPTION
Updated `phpunit/phpunit` to `~6.0` and `mockery/mockery` to `~1.0`

Dropped support to `PHP 5.6` and `HHVM`, as PHPUnit 6.0 [requires PHP 7.0](https://github.com/sebastianbergmann/phpunit/blob/master/composer.json#L25).