### PR TITLE
[3.0] Upgrade to PHP >= 5.6.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.6.4",
         "guzzlehttp/guzzle": "~6.0",
         "illuminate/contracts": "~5.4",
         "illuminate/http": "~5.4",


### PR DESCRIPTION
As `illuminate/contracts:~5.4` requires at minima this PHP version.
See https://github.com/laravel/framework/blob/5.4/composer.json#L18