### PR TITLE
Use Google Sign-in API instead of G+ for User Info

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -58,10 +58,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get('https://www.googleapis.com/plus/v1/people/me?', [
-            'query' => [
-                'prettyPrint' => 'false',
-            ],
+        $response = $this->getHttpClient()->get('https://www.googleapis.com/userinfo/v2/me', [
             'headers' => [
                 'Accept' => 'application/json',
                 'Authorization' => 'Bearer '.$token,
@@ -76,12 +73,10 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user)
     {
-        $avatarUrl = Arr::get($user, 'image.url');
-
         return (new User)->setRaw($user)->map([
-            'id' => $user['id'], 'nickname' => Arr::get($user, 'nickname'), 'name' => $user['displayName'],
-            'email' => Arr::get($user, 'emails.0.value'), 'avatar' => $avatarUrl,
-            'avatar_original' => preg_replace('/\?sz=([0-9]+)/', '', $avatarUrl),
+            'id' => $user['id'], 'nickname' => Arr::get($user, 'name'), 'name' => $user['name'],
+            'email' => Arr::get($user, 'email'), 'avatar' => Arr::get($user, 'picture') .'?sz=50',
+            'avatar_original' => Arr::get($user, 'picture'),
         ]);
     }
 }

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -75,7 +75,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     {
         return (new User)->setRaw($user)->map([
             'id' => $user['id'], 'nickname' => Arr::get($user, 'name'), 'name' => $user['name'],
-            'email' => Arr::get($user, 'email'), 'avatar' => Arr::get($user, 'picture') .'?sz=50',
+            'email' => Arr::get($user, 'email'), 'avatar' => Arr::get($user, 'picture').'?sz=50',
             'avatar_original' => Arr::get($user, 'picture'),
         ]);
     }


### PR DESCRIPTION
I'm not sure if this driver was originally designed explicitly for Google+, or just regular Google Sign-In. 

The below PR suggests that we remove the dependency of the G+ API on the Google Apps. The regular `/userinfo/v2/me` API provides the information socialite needs to get without any additional API's.

One thing to note about relying on the G+ API call - it requires the user to have set up / enabled their Google+ Profile, which is no longer done automatically on newly created Google accounts, and disabled on some G-Suite accounts.