### PR TITLE
Prevents cache issue when calling Twitter provider with different users

### DIFF
--- a/src/One/TwitterProvider.php
+++ b/src/One/TwitterProvider.php
@@ -15,7 +15,7 @@ class TwitterProvider extends AbstractProvider
             throw new InvalidArgumentException('Invalid request. Missing OAuth verifier.');
         }
 
-        $user = $this->server->getUserDetails($token = $this->getToken());
+        $user = $this->server->getUserDetails($token = $this->getToken(), $this->isNewUser($token->getIdentifier(), $token->getSecret()));
 
         $extraDetails = [
             'location' => $user->location,

--- a/tests/OAuthOneTest.php
+++ b/tests/OAuthOneTest.php
@@ -37,9 +37,9 @@ class OAuthOneTest extends PHPUnit_Framework_TestCase
         $server->shouldReceive('getTokenCredentials')->once()->with($temp, 'oauth_token', 'oauth_verifier')->andReturn(
             $token = m::mock(\League\OAuth1\Client\Credentials\TokenCredentials::class)
         );
-        $server->shouldReceive('getUserDetails')->once()->with($token)->andReturn($user = m::mock(\League\OAuth1\Client\Server\User::class));
-        $token->shouldReceive('getIdentifier')->once()->andReturn('identifier');
-        $token->shouldReceive('getSecret')->once()->andReturn('secret');
+        $server->shouldReceive('getUserDetails')->once()->with($token, false)->andReturn($user = m::mock(\League\OAuth1\Client\Server\User::class));
+        $token->shouldReceive('getIdentifier')->twice()->andReturn('identifier');
+        $token->shouldReceive('getSecret')->twice()->andReturn('secret');
         $user->uid = 'uid';
         $user->email = 'foo@bar.com';
         $user->extra = ['extra' => 'extra'];


### PR DESCRIPTION
The Twitter provider returns the wrong user when you authenticate using multiple different users in 1 request. This happens a lot on background workers where the it's processing jobs for multiple different users.

# Error
This is reproducible using 2 separate Twitter users in the same request:
```php
$users = [
    [
        'token'  => '...',
        'secret' => '...',
        'userId' => '1234',
    ], [
        'token'  => '...',
        'secret' => '...',
        'userId' => '5678',
    ],
];

try {
    $user1 = \Laravel\Socialite\Facades\Socialite::driver('twitter')->userFromTokenAndSecret($users[0]['token'], $users[0]['secret']);
    
    $user2 = \Laravel\Socialite\Facades\Socialite::driver('twitter')->userFromTokenAndSecret($users[1]['token'], $users[1]['secret']);
    
    if ($user1->id != $users[0]['userId'] || $user2->id != $users[1]['userId']) {
        throw new \Exception(sprintf('Wrong User ID 1: %s -- 2: %s', $user1->id, $user2->id));
    } else {
        echo('Correct user ID');
    }
} catch (\Exception $e) {
    echo('ERROR: ' . $e->getMessage());
}

```
Output: `ERROR: Wrong User ID 1: 1234 -- 2: 1234` **(Same User ID for both `$user1` and `$user2`. It's the correct user ID for `$user1`)**

# Fix
This PR fixes this problem by hashing `token_secret` for the given user and comparing it on the next request. If the hash doesn't match, it passes `true` for the `$force` [parameter on the OAuth client](https://github.com/thephpleague/oauth1-client/blob/90010af/src/Client/Server/Server.php#L190) which bypasses the cache.