### PR TITLE
[3.1] Changed isNewUser call to shouldBypassCache

### DIFF
--- a/src/One/TwitterProvider.php
+++ b/src/One/TwitterProvider.php
@@ -15,7 +15,7 @@ class TwitterProvider extends AbstractProvider
             throw new InvalidArgumentException('Invalid request. Missing OAuth verifier.');
         }
 
-        $user = $this->server->getUserDetails($token = $this->getToken(), $this->isNewUser($token->getIdentifier(), $token->getSecret()));
+        $user = $this->server->getUserDetails($token = $this->getToken(), $this->shouldBypassCache($token->getIdentifier(), $token->getSecret()));
 
         $extraDetails = [
             'location' => $user->location,


### PR DESCRIPTION
This fixes an issue introduced in v3.1 where the isNewUser method was renamed in https://github.com/laravel/socialite/commit/eeb666a5ca0dac7fa5a59b67841bc203fcd5c901 to shouldBypassCache, but it was not changed in the TwitterProvider (discovered in https://stackoverflow.com/q/51865672/899126).