### PR TITLE
changed API url to not use google+, updated mapping of user object

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -74,7 +74,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get('https://www.googleapis.com/plus/v1/people/me?', [
+        $response = $this->getHttpClient()->get('https://www.googleapis.com/userinfo/v2/me?', [
             'query' => [
                 'prettyPrint' => 'false',
             ],
@@ -93,8 +93,8 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     protected function mapUserToObject(array $user)
     {
         return (new User)->setRaw($user)->map([
-            'id' => $user['id'], 'nickname' => array_get($user, 'nickname'), 'name' => $user['displayName'],
-            'email' => $user['emails'][0]['value'], 'avatar' => array_get($user, 'image')['url'],
+            'id' => $user['id'], 'nickname' => array_get($user, 'nickname'), 'name' => $user['name'],
+            'email' => $user['email'], 'avatar' => array_get($user, 'picture'),
         ]);
     }
 }


### PR DESCRIPTION
In the previous version the developer needed to activate the google+ api in googles dev console. (not activating it results in 

```Client error: `GET https://www.googleapis.com/plus/v1/people/me?prettyPrint=false` resulted in a `403 Forbidden` response: {"error":{"errors":[{"domain":"usageLimits","reason":"accessNotConfigured","message":"Access Not Configured. Google+ API ```

With this api url we can get the email, name and avatar without google plus. I heard it is shutting down - so maybe this is useful.

Thanks and regards.