### PR TITLE
add extra header required for LinkedIn API

### DIFF
--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -71,6 +71,7 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
             'headers' => [
                 'x-li-format' => 'json',
                 'Authorization' => 'Bearer '.$token,
+                'x-li-src' => 'msdk'
             ],
         ]);
 


### PR DESCRIPTION
The issue is `Unable to verify access token` when login via API for LinkedIn for stateless API call for clients.
A hidden header `x-li-src` with value `msdk` is required to make it work.
More discusses here: https://stackoverflow.com/questions/28094926/linkedin-oauth2-unable-to-verify-access-token

Unfortunately this header key isn't documented by LinkedIn 