### PR TITLE
Fix mapping Google Userinfo to User Object

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -76,13 +76,13 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user)
     {
-        $avatarUrl = Arr::get($user, 'image.url');
+        $avatarUrl = Arr::get($user, 'picture');
 
         return (new User)->setRaw($user)->map([
             'id' => $user['id'],
             'nickname' => Arr::get($user, 'nickname'),
-            'name' => $user['displayName'],
-            'email' => Arr::get($user, 'emails.0.value'),
+            'name' => $user['name'],
+            'email' => Arr::get($user, 'email'),
             'avatar' => $avatarUrl,
             'avatar_original' => preg_replace('/\?sz=([0-9]+)/', '', $avatarUrl),
         ]);


### PR DESCRIPTION
It seems that Google's response when fetching the user info has changed.

Updated to reflect those changes. I could not find any change log on Google's side for reference.

#314 has some more info along with the specific error.

Google Returns the following for reference:
```
[
    "user" => [
        "id" => "",
        "email" => "",
        "verified_email" => "",
        "name" => "",
        "given_name" => "",
        "family_name" => "",
        "link" => "",
        "picture" => "",
        "locale" => ""
    ]
]
```