### PR TITLE
[4.0] Fix return type inconsistency

### DIFF
--- a/src/Contracts/Provider.php
+++ b/src/Contracts/Provider.php
@@ -7,7 +7,7 @@ interface Provider
     /**
      * Redirect the user to the authentication page for the provider.
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function redirect();
 

--- a/src/Two/ProviderInterface.php
+++ b/src/Two/ProviderInterface.php
@@ -7,7 +7,7 @@ interface ProviderInterface
     /**
      * Redirect the user to the authentication page for the provider.
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function redirect();
 


### PR DESCRIPTION
Changed return type to `\Illuminate\Http\RedirectResponse` because in reality it's returned in `AbstractProvider`.
I understand that it's subclass and satisfies this contract, but then it's inconsistent return types, because we are using Laravel specific `\Illuminate\Http\Request` instead `Symfony\Component\HttpFoundation\Request` parent class.