### PR TITLE
LinkedIn provider tweaks

### DIFF
--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -103,7 +103,10 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user)
     {
-        $name = Arr::get($user, 'firstName.localized.en_US').' '.Arr::get($user, 'lastName.localized.en_US');
+        $preferredLocale = Arr::get($user, 'firstName.preferredLocale.language') . '_' . Arr::get($user, 'firstName.preferredLocale.country');
+        $firstName = Arr::get($user, 'firstName.localized.' . $preferredLocale);
+        $lastName  = Arr::get($user, 'lastName.localized.' . $preferredLocale);
+
         $images = (array) Arr::get($user, 'profilePicture.displayImage~.elements', []);
         $avatar = Arr::first(Arr::where($images, function ($image) {
             return $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] === 100;
@@ -115,7 +118,7 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
         return (new User)->setRaw($user)->map([
             'id' => $user['id'],
             'nickname' => null,
-            'name' => $name,
+            'name' => $firstName . ' ' . $lastName,
             'email' => Arr::get($user, 'emailAddress'),
             'avatar' => Arr::get($avatar, 'identifiers.0.identifier'),
             'avatar_original' => Arr::get($originalAvatar, 'identifiers.0.identifier'),

--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -119,6 +119,8 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
             'id' => $user['id'],
             'nickname' => null,
             'name' => $firstName . ' ' . $lastName,
+            'first_name' => $firstName,
+            'last_name' => $lastName,
             'email' => Arr::get($user, 'emailAddress'),
             'avatar' => Arr::get($avatar, 'identifiers.0.identifier'),
             'avatar_original' => Arr::get($originalAvatar, 'identifiers.0.identifier'),


### PR DESCRIPTION
The name is now displayed correctly for users outside of the USA (I had the pl_PL locale, so the "firstName.localized.en_US" returned an empty string).

Also exposed the first_name and last_name fields which is useful in the forms and populating user table columns.