### PR TITLE
[4.0] Google avatar is default parameter

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -85,6 +85,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
             'email' => Arr::get($user, 'email'),
             'avatar' => $avatarUrl,
             'avatar_original' => preg_replace('/\?sz=([0-9]+)/', '', $avatarUrl),
+            'avatar_is_default'  => strpos($avatarUrl, '/mo/') === false ? false : true,
         ]);
     }
 }


### PR DESCRIPTION
Bring back is_default parameter for avatar to determine if avatar was uploaded by user or generated by google.
All default avatars contain '/mo/' string in their uri.