### PR TITLE
[4.0] Handle Google responses excluding 'name'

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -81,7 +81,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
         return (new User)->setRaw($user)->map([
             'id' => $user['id'],
             'nickname' => Arr::get($user, 'nickname'),
-            'name' => $user['name'],
+            'name' => Arr::get($user, 'name'),
             'email' => Arr::get($user, 'email'),
             'avatar' => $avatarUrl,
             'avatar_original' => preg_replace('/\?sz=([0-9]+)/', '', $avatarUrl),


### PR DESCRIPTION
I just had a Google login callback in production throw an exception because the 'name' JSON key was missing in the payload. Generally this would be a full response body:

```javascript
{
  "id": "1008...",
  "email": "derek...@...",
  "verified_email": true,
  "name": "Derek M...",
  "given_name": "Derek",
  "family_name": "M...",
  "link": "...",
  "picture": "...",
  "locale": "en",
}
```

But for incomplete (or service migrated?) accounts Google may exclude some keys. I can't find complete documentation covering how this OAuth2 scope is supposed to behave. They only offer a live-fetch form: https://developers.google.com/apis-explorer/#search/userinfo/m/oauth2/v2/oauth2.userinfo.v2.me.get

Socialite's 3.0 branch already handles this field as optional: https://github.com/laravel/socialite/pull/319/files#diff-2adaa1ef0c311c4b988908f120ea7557R84
