### PR TITLE
[4.0] Update Google API urls

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -37,7 +37,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getTokenUrl()
     {
-        return 'https://accounts.google.com/o/oauth2/token';
+        return 'https://www.googleapis.com/oauth2/v4/token';
     }
 
     /**
@@ -58,7 +58,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get('https://www.googleapis.com/userinfo/v2/me?', [
+        $response = $this->getHttpClient()->get('https://www.googleapis.com/oauth2/v3/userinfo', [
             'query' => [
                 'prettyPrint' => 'false',
             ],
@@ -76,15 +76,18 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user)
     {
-        $avatarUrl = Arr::get($user, 'picture');
+        // Deprecated: Fields added to keep backwards compatibility in 4.0. These will be removed in 5.0
+        $user['id'] = Arr::get($user, 'sub');
+        $user['verified_email'] = Arr::get($user, 'email_verified');
+        $user['link'] = Arr::get($user, 'profile');
 
         return (new User)->setRaw($user)->map([
-            'id' => $user['id'],
+            'id' => Arr::get($user, 'sub'),
             'nickname' => Arr::get($user, 'nickname'),
             'name' => Arr::get($user, 'name'),
             'email' => Arr::get($user, 'email'),
-            'avatar' => $avatarUrl,
-            'avatar_original' => preg_replace('/\?sz=([0-9]+)/', '', $avatarUrl),
+            'avatar' => $avatarUrl = Arr::get($user, 'picture'),
+            'original_avatar' => $avatarUrl,
         ]);
     }
 }


### PR DESCRIPTION
These updates ensure we're using the latest API urls from Google and continue to provide a working app after the shutdown of the Google+ functionality in March 2019.

By changing to the new v3 url for the user info retrieval, some of the keys from the response have changed. I've added the mappings to the old keys for the raw user data so nothing should break. These can be removed in v5.0 of Socialite.

Fixes https://github.com/laravel/socialite/issues/337