### PR TITLE
[4.0] Create a provider for Sign In with Apple

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Support\Manager;
+use Laravel\Socialite\Two\AppleProvider;
 use Laravel\Socialite\Two\GithubProvider;
 use Laravel\Socialite\Two\GitlabProvider;
 use Laravel\Socialite\Two\GoogleProvider;
@@ -109,6 +110,20 @@ class SocialiteManager extends Manager implements Contracts\Factory
 
         return $this->buildProvider(
             GitlabProvider::class, $config
+        );
+    }
+
+    /**
+     * Create an instance of the specified driver.
+     *
+     * @return \Laravel\Socialite\Two\AbstractProvider
+     */
+    protected function createAppleDriver()
+    {
+        $config = $this->app['config']['services.apple'];
+
+        return $this->buildProvider(
+            AppleProvider::class, $config
         );
     }
 

--- a/src/Two/AppleProvider.php
+++ b/src/Two/AppleProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Laravel\Socialite\Two;
+
+class AppleProvider extends AbstractProvider implements ProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = ['name', 'email'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://appleid.apple.com/auth/authorize', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://appleid.apple.com/auth/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenFields($code)
+    {
+        return parent::getTokenFields($code) + ['grant_type' => 'authorization_code'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        // TODO: Implement getUserByToken() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        // TODO: Implement mapUserToObject() method.
+    }
+}


### PR DESCRIPTION
This starts to add `Sign In with Apple` support, and is based off of [Aaron Parecki's blog on Okta](https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-apple).

I understand that the readme states no new adapters will be accepted, but I feel that Apple would be a good fit for an additional provider as it is used by so many people.

The documentation for Sign In with Apple is at:
- [Sign In with Apple Official Information](https://developer.apple.com/sign-in-with-apple)
- [Sign In with Apple REST API Documentation](https://developer.apple.com/documentation/signinwithapplerestapi)
- [Sign In with Apple JS Documentation](https://developer.apple.com/documentation/signinwithapplejs)

I haven't been able to implement the `getUserByToken` or `mapUserToObject` methods yet unfortunately as I can't find an API endpoint for this. I've opened this as a draft for this reason, so if anyone finds an endpoint for user data, the PR can be completed. However, if this requires closing until until these endpoints are found, I understand.

This is a new provider, so it won't break any existing features.

------

See issue laravel/socialite#369

_PR originally created at SocialiteProviders/Providers#315_