### PR TITLE
[4.x] Sign in with apple id

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Introduction
 
-Laravel Socialite provides an expressive, fluent interface to OAuth authentication with Facebook, Twitter, Google, LinkedIn, GitHub, GitLab and Bitbucket. It handles almost all of the boilerplate social authentication code you are dreading writing.
+Laravel Socialite provides an expressive, fluent interface to OAuth authentication with Facebook, Twitter, Google, LinkedIn, GitHub, GitLab, Bitbucket and Apple. It handles almost all of the boilerplate social authentication code you are dreading writing.
 
 **We are not accepting new adapters.**
 

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Manager;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravel\Socialite\One\TwitterProvider;
+use Laravel\Socialite\Two\AppleProvider;
 use Laravel\Socialite\Two\BitbucketProvider;
 use Laravel\Socialite\Two\FacebookProvider;
 use Laravel\Socialite\Two\GithubProvider;
@@ -80,7 +81,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
         $config = $this->app['config']['services.linkedin'];
 
         return $this->buildProvider(
-          LinkedInProvider::class, $config
+            LinkedInProvider::class, $config
         );
     }
 
@@ -94,7 +95,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
         $config = $this->app['config']['services.bitbucket'];
 
         return $this->buildProvider(
-          BitbucketProvider::class, $config
+            BitbucketProvider::class, $config
         );
     }
 
@@ -109,6 +110,20 @@ class SocialiteManager extends Manager implements Contracts\Factory
 
         return $this->buildProvider(
             GitlabProvider::class, $config
+        );
+    }
+
+    /**
+     * Create an instance of the specified driver.
+     *
+     * @return \Laravel\Socialite\Two\AbstractProvider
+     */
+    protected function createAppleDriver()
+    {
+        $config = $this->app['config']['services.apple'];
+
+        return $this->buildProvider(
+            AppleProvider::class, $config
         );
     }
 
@@ -168,8 +183,8 @@ class SocialiteManager extends Manager implements Contracts\Factory
         $redirect = value($config['redirect']);
 
         return Str::startsWith($redirect, '/')
-                    ? $this->app['url']->to($redirect)
-                    : $redirect;
+            ? $this->app['url']->to($redirect)
+            : $redirect;
     }
 
     /**

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -212,13 +212,17 @@ abstract class AbstractProvider implements ProviderContract
 
         $response = $this->getAccessTokenResponse($this->getCode());
 
-        $user = $this->mapUserToObject($this->getUserByToken(
-            $token = Arr::get($response, 'access_token')
-        ));
+        $token = Arr::get($response, 'access_token');
+        $user = $this->mapUserToObject($this->getUserByAccessTokenResponse($response));
 
         return $user->setToken($token)
-                    ->setRefreshToken(Arr::get($response, 'refresh_token'))
-                    ->setExpiresIn(Arr::get($response, 'expires_in'));
+            ->setRefreshToken(Arr::get($response, 'refresh_token'))
+            ->setExpiresIn(Arr::get($response, 'expires_in'));
+    }
+
+    protected function getUserByAccessTokenResponse($response)
+    {
+        return $this->getUserByToken($token = Arr::get($response, 'access_token'));
     }
 
     /**

--- a/src/Two/AppleProvider.php
+++ b/src/Two/AppleProvider.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Laravel\Socialite\Two;
+
+use Illuminate\Support\Arr;
+
+class AppleProvider extends AbstractProvider implements ProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = ['name', 'email'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://appleid.apple.com/auth/authorize', $state).'&response_mode=form_post';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://appleid.apple.com/auth/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenFields($code)
+    {
+        return parent::getTokenFields($code) + ['grant_type' => 'authorization_code'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByAccessTokenResponse($response)
+    {
+        return json_decode(base64_decode(explode('.', Arr::get($response, 'id_token'))[1]), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        // Refresh_token
+        // User info already in the token response, you only get the email the first time
+        // No user meta data in the grant_type refresh_token, https://developer.apple.com/documentation/signinwithapplerestapi/generate_and_validate_tokens
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id' => $user['sub'],
+            'nickname' => null,
+            'name' => null,
+            'email' => Arr::get($user, 'email'),
+            'avatar' => null,
+        ]);
+    }
+}

--- a/tests/AppleProviderTest.php
+++ b/tests/AppleProviderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Socialite\Tests;
+
+use GuzzleHttp\Client;
+use Illuminate\Http\Request;
+use Laravel\Socialite\Two\AppleProvider;
+use Laravel\Socialite\Two\User;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+class AppleProviderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    public function test_get_apple_token()
+    {
+        $request = m::mock(Request::class);
+        $request->shouldReceive('input')->with('code')->andReturn('fake-code');
+
+        $accessTokenResponse = m::mock(ResponseInterface::class);
+        $accessTokenResponse->shouldReceive('getBody')->andReturn(json_encode(['id_token' => 'eyJraWQiOiJBSURPUEDSDwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczpcL1wvYXBwbGVpZC5hcHBsZS5jb20iLCJhdWQiOiJ3d3cuZXhhbXBsZS5jb20iLCJleHAiOjE1NjE0OTA2MTUsImlhdCI6MTU2MTUzMzU4OCwic3ViIjoiMDAwMTMyLmMzTWlPaUpvZEhSd2N6b3ZMMkZ3Y0d4bGFXUWFzZHNhLjg5MTQiLCJhdF9oYXNoIjoiQnBiVmVmTm5waVBUY1BzcWt3VEppZyIsImVtYWlsIjoiZXhhbXBsZUBwcml2YXRlcmVsYXkuYXBwbGVpZC5jb20ifQ==.SyCF8jT50FHALit-u9H_TyzPikirYnDq1RiDT3ennHQrLOAcRE4bDmVM1qlG2cfHPH5OtpyQZIjGi_r9v7ZoN2EfyDGlg08yEWGwwCNlrCkcHcA9gjNN2RYmT4Yt3toRLgnwSDyzHOP6FS7I1kzwcdZmJTuGrYPThxe80F6rQABUWUBDAl2KgP7ujt1j8H3LrfV0r3RKTHA7azWWu9rVAFrx1_IeRk-ASDW0OPrqDJoF8YdZF1Da4-br-gTOt_LJhZFhuPh1WDgZj6AAcytTrSL4AhW2BrN_U0bMw88nw7k9OZbcbDNb-j3hEAkQdvZYEBHIRtEMxrzTAgs7oxbtg']));
+
+        $guzzle = m::mock(Client::class);
+        $guzzle->shouldReceive('post')->once()->andReturn($accessTokenResponse);
+
+        $provider = new AppleProvider($request, 'client_id', 'client_secret', 'redirect');
+        $provider->stateless();
+        $provider->setHttpClient($guzzle);
+
+        $user = $provider->user();
+
+        $this->assertInstanceOf(User::class, $user);
+
+        $this->assertEquals('example@privaterelay.appleid.com', $user->getEmail()); //TODO After the apple update
+        $this->assertEquals('000132.c3MiOiJodHRwczovL2FwcGxlaWQasdsa.8914', $user->getId());
+    }
+}


### PR DESCRIPTION
This PR will add the apple provider in socialite. See [example](https://github.com/theodh/example-socialite-apple)

## Setup
Configure [apple sign in](https://developer.apple.com/sign-in-with-apple/get-started/), a good starting point is the blog of [Aaron Parecki](https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-apple)

Add the following variables in your .env file:

SOCIAL_CLIENTID_APPLE=YOUR_APPLE_CLIENT_ID

SOCIAL_CLIENT_SECRET_APPLE=[Client_secret](https://github.com/aaronpk/sign-in-with-apple-example/blob/master/client-secret.rb)

SOCIAL_REDIRECT_APPLE=/social-auth/handle/apple/

The following points should be considered in order to use the apple provider in [socialite](https://github.com/laravel/socialite/issues/369):

### Email only in the first handle
You only get the email address in the first login of the user. You should save the email address (user->email) and the apple identifier (sub) (user->id). The second time you use this identifier to find the user in your laravel applications.
See [SocialAuthController -getHandleCallback](https://github.com/theodh/example-socialite-apple/blob/155e35bcc16a2de8e6b90432a73bc0f9c9995c9d/src/app/Http/Controllers/Auth/SocialAuthController.php#L33)

### Handle a post request of the authorization token
Add your [authorization handle post](https://developer.apple.com/documentation/signinwithapplerestapi/generate_and_validate_tokens) request in the [VerifyCsrfToken](https://github.com/theodh/example-socialite-apple/blob/155e35bcc16a2de8e6b90432a73bc0f9c9995c9d/src/app/Http/Middleware/VerifyCsrfToken.php#L22), in this example:

```
 protected $except = [
        '/social-auth/handle/apple'
    ];
```

### Client Secret
Refresh the client_secret apple key each six months (write a automatic cronjob)

A cronjob example with [client.rb](https://github.com/aaronpk/sign-in-with-apple-example/blob/master/client-secret.rb):

```
#!/usr/bin/env bash

source /usr/local/rvm/environments/ruby-2.6.3

cd /your_path_apple_sign_in/

ruby client.rb apple_client.txt

/bin/cp -f apple_client.txt /your_laravel_path/storage/apple/apple_client.txt

chown your_linux_user/your_linux_group /your_laravel_path/storage/apple/apple_client.txt
```

Other solution to refresh your client secret, would be the one below:

```
 public function generateClientSecret()
    {
        $privateKeyFile = Storage::disk('local')->get('crapple.pkey');
        $team_id = ''; //value got from apple
        $key_id = ''; //value got from apple
        $signer = new \Lcobucci\JWT\Signer\Ecdsa\Sha256();
        $privateKey = new Key($privateKeyFile);
        $token = (new Builder())->issuedBy($team_id)// Configures the issuer (iss claim)
        ->permittedFor("https://appleid.apple.com")// Configures the audience (aud claim)
        ->issuedAt(time())// Configures the time that the token was issue (iat claim)
        ->expiresAt(time() + 86400 * 180)// Configures the expiration time of the token (exp claim)
        ->relatedTo(config('app.apple_client_id')) //Configures the subject
        ->withHeader('kid', $key_id)
            ->withHeader('type', 'JWT')
            ->withHeader('alg', 'ES256')
            ->getToken($signer, $privateKey); // Retrieves the generated token
        //$a = $token->getHeaders(); // Retrieves the token headers
        //$b = $token->getClaims(); // Retrieves the token claims

        return $token->__toString();
    }
```

and in order to check if the client_secret (that's a token btw!) expired, use the code below:

```
    private function isExpiredSecret($token)
    {
        $token = (new Parser())->parse((string)$token); // Parses from a string
        return $token->isExpired();
    }
```

### Private email replay
If the user is using his anonymous email-address, a standard email relay (mandrill, sendgrid) is not possible [at this moment](https://forums.developer.apple.com/thread/122270).

## If everything is working
On callback endpoint, if everything is ok,

```
        $driver = Socialite::driver($provider);
        $user = $driver->user();
```

the $user object would contain (depending if it's first time or not when the endpoint is called by Apple)
the unique identifier for the user from Apple and email address. The e-mail address is returned only first time, any successive calls do not contain the e-mail address. This is the way Sign In with Apple works.
During development you could delete your apple app https://appleid.apple.com/account/manage
(security -to test this again

## Troubleshouting
### Invalid grant
* Invalid grant: check that your client_id and client_secret has the same service_id.
* Timeout

### Invalid state exception
* Initiate the apple request again, state is invalid.
