### PR TITLE
[5.x] Only use the `read_user` scope for GitLab by default

### DIFF
--- a/src/Two/GitlabProvider.php
+++ b/src/Two/GitlabProvider.php
@@ -5,6 +5,13 @@ namespace Laravel\Socialite\Two;
 class GitlabProvider extends AbstractProvider implements ProviderInterface
 {
     /**
+     * The scopes being requested.
+     *
+     * @var array
+     */
+    protected $scopes = ['read_user'];
+
+    /**
      * {@inheritdoc}
      */
     protected function getAuthUrl($state)


### PR DESCRIPTION
This makes the GitLab provider use a smaller scope by default. This has two benefits:

- If the user created the application without checking any of the scope checkboxes, GitLab will implicitly check all the boxes when submitting the form. This can result in all scopes being granted to the application, which is very broad.
- If the user created the application with only the `read_user` scope being grantable to applications, Socialite will work correctly out of the box (without requiring the user to override the scopes being requested on the Laravel side).

This closes #402.