### PR TITLE
[4.x] Change default graph version, manually set desired version

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -178,11 +178,11 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
 
 
     /**
-     * Replace default graph version to use with given request
+     * Replace default graph version to use with given request.
      *
      * @return $this
      */
-    public function usingGraphVersion(string $version) 
+    public function usingGraphVersion(string $version)
     {
         $this->version = $version;
 

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -176,7 +176,6 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
         return $this;
     }
 
-
     /**
      * Replace default graph version to use with given request.
      *

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -19,7 +19,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      *
      * @var string
      */
-    protected $version = 'v3.0';
+    protected $version = 'v3.3';
 
     /**
      * The user fields being requested.
@@ -172,6 +172,19 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     public function reRequest()
     {
         $this->reRequest = true;
+
+        return $this;
+    }
+
+
+    /**
+     * Replace default graph version to use with given request
+     *
+     * @return $this
+     */
+    public function usingGraphVersion(string $version) 
+    {
+        $this->version = $version;
 
         return $this;
     }

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -177,8 +177,9 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     }
 
     /**
-     * Replace default graph version to use with given request.
+     * Specify which graph version should be used.
      *
+     * @param  string  $version
      * @return $this
      */
     public function usingGraphVersion(string $version)

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -66,7 +66,7 @@ class OAuthTwoTest extends TestCase
         $provider = new FacebookTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock(stdClass::class);
         $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
-        $provider->http->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.0/oauth/access_token', [
+        $provider->http->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.3/oauth/access_token', [
             $postKey => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
         ])->andReturn($response = m::mock(stdClass::class));
         $response->shouldReceive('getBody')->once()->andReturn(json_encode(['access_token' => 'access_token', 'expires' => 5183085]));


### PR DESCRIPTION
It changes default graph version to 3.3.

Also, it introduces a way of changing the default version. I'm still having second thoughts regarding this, as it might break functionality if facebook decides to change how object is accessed, and we will need a proper mapping between graph versions. 

The usage I have in mind:

```php
return Socialite::driver('facebook')->usingGraphVersion('v5.0')->redirect();
```

Let me know what do you think
