### PR TITLE
Argument 1 passed to Server::getTokenCredentials() must be an instance of TemporaryCredentials, string given

### DIFF
--- a/src/One/AbstractProvider.php
+++ b/src/One/AbstractProvider.php
@@ -126,7 +126,7 @@ abstract class AbstractProvider implements ProviderContract
      */
     protected function getToken()
     {
-        $temp = $this->request->session()->get('oauth.temp');
+        $temp = unserialize($this->request->session()->get('oauth.temp'));
 
         return $this->server->getTokenCredentials(
             $temp, $this->request->get('oauth_token'), $this->request->get('oauth_verifier')


### PR DESCRIPTION
After login in Twitter:

Argument 1 passed to League\OAuth1\Client\Server\Server::getTokenCredentials() must be an instance of League\OAuth1\Client\Credentials\TemporaryCredentials, string given, called in vendor/laravel/socialite/src/One/AbstractProvider.php on line 132
