### PR TITLE
[4.x] Allow route/action based redirect url definition

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -167,6 +167,20 @@ class SocialiteManager extends Manager implements Contracts\Factory
     {
         $redirect = value($config['redirect']);
 
+        if (is_array($redirect)) {
+            if (array_key_exists('route', $redirect)) {
+                return $this->app['url']->route($redirect['route'], $redirect['parameters'] ?? []);
+            }
+
+            if (array_key_exists('action', $redirect)) {
+                return $this->app['url']->action($redirect['action'], $redirect['parameters'] ?? []);
+            }
+
+            throw new InvalidArgumentException(
+                'Either an action or a route should be defined when an array is passed as redirect url.'
+            );
+        }
+
         return Str::startsWith($redirect, '/')
                     ? $this->app['url']->to($redirect)
                     : $redirect;


### PR DESCRIPTION
Currently one can only define the redirect route by entering it to the config file because the router is not available when the config files are loaded (or by passing a callback but that makes the config non-serializable).

This pull request makes possible to use either routes or actions by passing them in an array form:
```php
['route' => 'name']; // named route
['action' => 'controller@method']; // route based on action
['route' => 'name', 'parameters' => ['random', 'stuff']]; // with additional parameters
```

As an alternative I have considered introducing a redirect_route key but I think this is a superior solution.