### PR TITLE
[4.x] Override SocialiteServiceProvider::isDeferred() to mark as deferred.

### DIFF
--- a/src/SocialiteServiceProvider.php
+++ b/src/SocialiteServiceProvider.php
@@ -8,13 +8,6 @@ use Laravel\Socialite\Contracts\Factory;
 class SocialiteServiceProvider extends ServiceProvider
 {
     /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = true;
-
-    /**
      * Register the service provider.
      *
      * @return void
@@ -34,5 +27,15 @@ class SocialiteServiceProvider extends ServiceProvider
     public function provides()
     {
         return [Factory::class];
+    }
+
+    /**
+     * Determine if the provider is deferred.
+     *
+     * @return bool
+     */
+    public function isDeferred()
+    {
+        return true;
     }
 }


### PR DESCRIPTION
`Illuminate\Contracts\Support\DeferrableProvider` is only available under 5.8 and above. Since we still supporting 5.7 the only option is to override the method.

<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
