### PR TITLE
[4.x] Replace ArrayAccess interface calls with Container::make

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -35,7 +35,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createGithubDriver()
     {
-        $config = $this->app['config']['services.github'];
+        $config = $this->app->make('config')['services.github'];
 
         return $this->buildProvider(
             GithubProvider::class, $config
@@ -49,7 +49,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createFacebookDriver()
     {
-        $config = $this->app['config']['services.facebook'];
+        $config = $this->app->make('config')['services.facebook'];
 
         return $this->buildProvider(
             FacebookProvider::class, $config
@@ -63,7 +63,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createGoogleDriver()
     {
-        $config = $this->app['config']['services.google'];
+        $config = $this->app->make('config')['services.google'];
 
         return $this->buildProvider(
             GoogleProvider::class, $config
@@ -77,7 +77,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createLinkedinDriver()
     {
-        $config = $this->app['config']['services.linkedin'];
+        $config = $this->app->make('config')['services.linkedin'];
 
         return $this->buildProvider(
           LinkedInProvider::class, $config
@@ -91,7 +91,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createBitbucketDriver()
     {
-        $config = $this->app['config']['services.bitbucket'];
+        $config = $this->app->make('config')['services.bitbucket'];
 
         return $this->buildProvider(
           BitbucketProvider::class, $config
@@ -105,7 +105,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createGitlabDriver()
     {
-        $config = $this->app['config']['services.gitlab'];
+        $config = $this->app->make('config')['services.gitlab'];
 
         return $this->buildProvider(
             GitlabProvider::class, $config
@@ -122,7 +122,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
     public function buildProvider($provider, $config)
     {
         return new $provider(
-            $this->app['request'], $config['client_id'],
+            $this->app->make('request'), $config['client_id'],
             $config['client_secret'], $this->formatRedirectUrl($config),
             Arr::get($config, 'guzzle', [])
         );
@@ -135,10 +135,10 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createTwitterDriver()
     {
-        $config = $this->app['config']['services.twitter'];
+        $config = $this->app->make('config')['services.twitter'];
 
         return new TwitterProvider(
-            $this->app['request'], new TwitterServer($this->formatConfig($config))
+            $this->app->make('request'), new TwitterServer($this->formatConfig($config))
         );
     }
 
@@ -168,7 +168,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
         $redirect = value($config['redirect']);
 
         return Str::startsWith($redirect, '/')
-                    ? $this->app['url']->to($redirect)
+                    ? $this->app->make('url')->to($redirect)
                     : $redirect;
     }
 


### PR DESCRIPTION
Since the SocialiteManager class accepts an instance of the Container interface which not implements ArrayAccess it should use the `make` method instead of array access.

This pull request updates the code to use the `make` method where necessary.

Actually it probably shouldn't use ArrayAccess on the config instance either, but it is not defined anywhere that the make('config') can return an object that only implements the Repository interface and not the base class itself.