### PR TITLE
[4.x] Allow route/action based redirect url definition

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -35,7 +35,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createGithubDriver()
     {
-        $config = $this->app['config']['services.github'];
+        $config = $this->app->make('config')['services.github'];
 
         return $this->buildProvider(
             GithubProvider::class, $config
@@ -49,7 +49,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createFacebookDriver()
     {
-        $config = $this->app['config']['services.facebook'];
+        $config = $this->app->make('config')['services.facebook'];
 
         return $this->buildProvider(
             FacebookProvider::class, $config
@@ -63,7 +63,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createGoogleDriver()
     {
-        $config = $this->app['config']['services.google'];
+        $config = $this->app->make('config')['services.google'];
 
         return $this->buildProvider(
             GoogleProvider::class, $config
@@ -77,7 +77,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createLinkedinDriver()
     {
-        $config = $this->app['config']['services.linkedin'];
+        $config = $this->app->make('config')['services.linkedin'];
 
         return $this->buildProvider(
           LinkedInProvider::class, $config
@@ -91,7 +91,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createBitbucketDriver()
     {
-        $config = $this->app['config']['services.bitbucket'];
+        $config = $this->app->make('config')['services.bitbucket'];
 
         return $this->buildProvider(
           BitbucketProvider::class, $config
@@ -105,7 +105,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createGitlabDriver()
     {
-        $config = $this->app['config']['services.gitlab'];
+        $config = $this->app->make('config')['services.gitlab'];
 
         return $this->buildProvider(
             GitlabProvider::class, $config
@@ -122,7 +122,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
     public function buildProvider($provider, $config)
     {
         return new $provider(
-            $this->app['request'], $config['client_id'],
+            $this->app->make('request'), $config['client_id'],
             $config['client_secret'], $this->formatRedirectUrl($config),
             Arr::get($config, 'guzzle', [])
         );
@@ -135,10 +135,10 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createTwitterDriver()
     {
-        $config = $this->app['config']['services.twitter'];
+        $config = $this->app->make('config')['services.twitter'];
 
         return new TwitterProvider(
-            $this->app['request'], new TwitterServer($this->formatConfig($config))
+            $this->app->make('request'), new TwitterServer($this->formatConfig($config))
         );
     }
 
@@ -168,7 +168,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
         $redirect = value($config['redirect']);
 
         return Str::startsWith($redirect, '/')
-                    ? $this->app['url']->to($redirect)
+                    ? $this->app->make('url')->to($redirect)
                     : $redirect;
     }
 

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -169,11 +169,11 @@ class SocialiteManager extends Manager implements Contracts\Factory
 
         if (is_array($redirect)) {
             if (array_key_exists('route', $redirect)) {
-                return $this->app['url']->route($redirect['route'], $redirect['parameters'] ?? []);
+                return $this->app->make('url')->route($redirect['route'], $redirect['parameters'] ?? []);
             }
 
             if (array_key_exists('action', $redirect)) {
-                return $this->app['url']->action($redirect['action'], $redirect['parameters'] ?? []);
+                return $this->app->make('url')->action($redirect['action'], $redirect['parameters'] ?? []);
             }
 
             throw new InvalidArgumentException(

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -167,6 +167,20 @@ class SocialiteManager extends Manager implements Contracts\Factory
     {
         $redirect = value($config['redirect']);
 
+        if (is_array($redirect)) {
+            if (array_key_exists('route', $redirect)) {
+                return $this->app['url']->route($redirect['route'], $redirect['parameters'] ?? []);
+            }
+
+            if (array_key_exists('action', $redirect)) {
+                return $this->app['url']->action($redirect['action'], $redirect['parameters'] ?? []);
+            }
+
+            throw new InvalidArgumentException(
+                'Either an action or a route should be defined when an array is passed as redirect url.'
+            );
+        }
+
         return Str::startsWith($redirect, '/')
                     ? $this->app->make('url')->to($redirect)
                     : $redirect;

--- a/tests/RouteGenerationTest.php
+++ b/tests/RouteGenerationTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Laravel\Socialite\Tests;
+
+use function GuzzleHttp\Psr7\parse_query;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Routing\UrlGenerator;
+use Illuminate\Contracts\Session\Session;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Laravel\Socialite\SocialiteManager;
+use Laravel\Socialite\Two\FacebookProvider;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class RouteGenerationTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    public function testValidRedirectUriIsPassedThrough()
+    {
+        $driver = $this->driver([
+            'client_id' => 'id',
+            'client_secret' => 'secret',
+            'redirect' => 'https://example.com/callback',
+        ]);
+
+        $this->assertEquals('https://example.com/callback', $this->redirectUrlFromResponse($driver->redirect()));
+    }
+
+    public function testRedirectUriCanBeGeneratedFromUri()
+    {
+        $url = m::mock(UrlGenerator::class);
+        $url->shouldReceive('to')->with('/callback')->andReturn('https://example.com/callback');
+
+        $driver = $this->driver([
+            'client_id' => 'id',
+            'client_secret' => 'secret',
+            'redirect' => '/callback',
+        ], $url);
+
+        $this->assertEquals('https://example.com/callback', $this->redirectUrlFromResponse($driver->redirect()));
+    }
+
+    public function testRedirectUriCanBeGeneratedFromAction()
+    {
+        $url = m::mock(UrlGenerator::class);
+        $url->shouldReceive('action')->with('callback', [0, 21])->andReturn('https://example.com/callback');
+
+        $driver = $this->driver([
+            'client_id' => 'id',
+            'client_secret' => 'secret',
+            'redirect' => ['action' => 'callback', 'parameters' => [0, 21]],
+        ], $url);
+
+        $this->assertEquals('https://example.com/callback', $this->redirectUrlFromResponse($driver->redirect()));
+    }
+
+    public function testRedirectUriCanBeGeneratedFromRoute()
+    {
+        $url = m::mock(UrlGenerator::class);
+        $url->shouldReceive('route')->with('callback', [0, 21])->andReturn('https://example.com/callback');
+
+        $driver = $this->driver([
+            'client_id' => 'id',
+            'client_secret' => 'secret',
+            'redirect' => ['route' => 'callback', 'parameters' => [0, 21]],
+        ], $url);
+
+        $this->assertEquals('https://example.com/callback', $this->redirectUrlFromResponse($driver->redirect()));
+    }
+
+    public function testRedirectUriCannotBeGeneratedFromInvalidArray()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->driver([
+            'client_id' => 'id',
+            'client_secret' => 'secret',
+            'redirect' => [],
+        ]);
+    }
+
+    protected function driver(array $driverConfig, ?UrlGenerator $url = null): FacebookProvider
+    {
+        $config = m::mock(Repository::class, \ArrayAccess::class);
+        $config->shouldReceive('offsetGet')->with('services.facebook')->andReturn($driverConfig);
+
+        $request = Request::create('foo');
+        $request->setLaravelSession($session = m::mock(Session::class));
+        $session->shouldIgnoreMissing();
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('config')->andReturn($config);
+        $container->shouldReceive('make')->with('request')->andReturn($request);
+        $container->shouldReceive('make')->with('url')->andReturn($url);
+
+        return (new SocialiteManager($container))->driver('facebook');
+    }
+
+    protected function redirectUrlFromResponse(RedirectResponse $response): string
+    {
+        return parse_query(Str::after($response->getTargetUrl(), '?'))['redirect_uri'];
+    }
+}


### PR DESCRIPTION
Currently one can only define the redirect route by entering it to the config file because the router is not available when the config files are loaded (or by passing a callback but that makes the config non-serializable). This means that the urls have to be defined at least two places and updated later if changed.

This pull request makes possible to use either routes or actions by passing them in an array form:

```php
['route' => 'name'];
```
Generates an URL for a named route.

```php
['action' => 'controller@method'];
```
Generates an URL for a controller action.

```php
['route' => 'name', 'parameters' => ['random', 'stuff']]);
```
Additional parameter can be also supplied just like to the route method.

As an alternative I have considered introducing a redirect_route key but I think this is a superior solution.

Follow up to #411, solves #388