### PR TITLE
Fix PHPUnit 8->9 deprectiations messages

### DIFF
--- a/tests/OAuthOneTest.php
+++ b/tests/OAuthOneTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Socialite\Tests;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use InvalidArgumentException;
 use Laravel\Socialite\One\User as SocialiteUser;
 use Laravel\Socialite\Tests\Fixtures\OAuthOneTestProviderStub;
 use League\OAuth1\Client\Credentials\TemporaryCredentials;
@@ -66,11 +67,10 @@ class OAuthOneTest extends TestCase
         $this->assertSame(['extra' => 'extra'], $user->user);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testExceptionIsThrownWhenVerifierIsMissing()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $server = m::mock(Twitter::class);
         $request = Request::create('foo');
         $request->setLaravelSession($session = m::mock(Session::class));

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -8,6 +8,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Laravel\Socialite\Tests\Fixtures\FacebookTestProviderStub;
 use Laravel\Socialite\Tests\Fixtures\OAuthTwoTestProviderStub;
+use Laravel\Socialite\Two\InvalidStateException;
 use Laravel\Socialite\Two\User;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -79,11 +80,10 @@ class OAuthTwoTest extends TestCase
         $this->assertEquals(5183085, $user->expiresIn);
     }
 
-    /**
-     * @expectedException \Laravel\Socialite\Two\InvalidStateException
-     */
     public function testExceptionIsThrownIfStateIsInvalid()
     {
+        $this->expectException(InvalidStateException::class);
+
         $request = Request::create('foo', 'GET', ['state' => str_repeat('B', 40), 'code' => 'code']);
         $request->setLaravelSession($session = m::mock(Session::class));
         $session->shouldReceive('pull')->once()->with('state')->andReturn(str_repeat('A', 40));
@@ -91,11 +91,10 @@ class OAuthTwoTest extends TestCase
         $provider->user();
     }
 
-    /**
-     * @expectedException \Laravel\Socialite\Two\InvalidStateException
-     */
     public function testExceptionIsThrownIfStateIsNotSet()
     {
+        $this->expectException(InvalidStateException::class);
+
         $request = Request::create('foo', 'GET', ['state' => 'state', 'code' => 'code']);
         $request->setLaravelSession($session = m::mock(Session::class));
         $session->shouldReceive('pull')->once()->with('state');


### PR DESCRIPTION
In PHPUnit 9, all ` @expectedException*` docblocks use will be soon disabled.
For now, we with PHPUnit 8, we have depreciation messages.

This PR fixes that.