### PR TITLE
[4.0] Enforce stricter assertions

### DIFF
--- a/tests/LinkedInProviderTest.php
+++ b/tests/LinkedInProviderTest.php
@@ -56,7 +56,7 @@ class LinkedInProviderTest extends TestCase
         $user = $provider->user();
 
         $this->assertInstanceOf(User::class, $user);
-        $this->assertEquals($userId, $user->getId());
-        $this->assertEquals(null, $user->getEmail());
+        $this->assertSame($userId, $user->getId());
+        $this->assertNull($user->getEmail());
     }
 }

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -76,7 +76,7 @@ class OAuthTwoTest extends TestCase
         $this->assertSame('foo', $user->id);
         $this->assertSame('access_token', $user->token);
         $this->assertNull($user->refreshToken);
-        $this->assertEquals(5183085, $user->expiresIn);
+        $this->assertSame(5183085, $user->expiresIn);
     }
 
     /**


### PR DESCRIPTION
This PR enforces stricter assertions, using `assertSame` instead of `assertEquals`, or `assertNull` when possible.

