### PR TITLE
[4.x] use Authorization header instead of using the `access_token` query parameter

### DIFF
--- a/src/Two/GithubProvider.php
+++ b/src/Two/GithubProvider.php
@@ -35,10 +35,10 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $userUrl = 'https://api.github.com/user?access_token='.$token;
+        $userUrl = 'https://api.github.com/user';
 
         $response = $this->getHttpClient()->get(
-            $userUrl, $this->getRequestOptions()
+            $userUrl, $this->getRequestOptions($token)
         );
 
         $user = json_decode($response->getBody(), true);
@@ -58,11 +58,11 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getEmailByToken($token)
     {
-        $emailsUrl = 'https://api.github.com/user/emails?access_token='.$token;
+        $emailsUrl = 'https://api.github.com/user/emails';
 
         try {
             $response = $this->getHttpClient()->get(
-                $emailsUrl, $this->getRequestOptions()
+                $emailsUrl, $this->getRequestOptions($token)
             );
         } catch (Exception $e) {
             return;
@@ -92,13 +92,15 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
     /**
      * Get the default options for an HTTP request.
      *
+     * @param string $token
      * @return array
      */
-    protected function getRequestOptions()
+    protected function getRequestOptions($token)
     {
         return [
             'headers' => [
                 'Accept' => 'application/vnd.github.v3+json',
+                'Authorization' => 'token '.$token,
             ],
         ];
     }


### PR DESCRIPTION
Github is deprecating using access_token as query parameter and they recommend sending OAuth tokens using the Authorization header.
as mentioned in this issue #427

see https://developer.github.com/v3/#oauth2-token-sent-in-a-header