### PR TITLE
[4.x] Removed array access on the container instance in SocialiteManger.php

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -35,7 +35,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createGithubDriver()
     {
-        $config = $this->container['config']['services.github'];
+        $config = $this->container->make('config')['services.github'];
 
         return $this->buildProvider(
             GithubProvider::class, $config
@@ -49,7 +49,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createFacebookDriver()
     {
-        $config = $this->container['config']['services.facebook'];
+        $config = $this->container->make('config')['services.facebook'];
 
         return $this->buildProvider(
             FacebookProvider::class, $config
@@ -63,7 +63,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createGoogleDriver()
     {
-        $config = $this->container['config']['services.google'];
+        $config = $this->container->make('config')['services.google'];
 
         return $this->buildProvider(
             GoogleProvider::class, $config
@@ -77,7 +77,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createLinkedinDriver()
     {
-        $config = $this->container['config']['services.linkedin'];
+        $config = $this->container->make('config')['services.linkedin'];
 
         return $this->buildProvider(
           LinkedInProvider::class, $config
@@ -91,7 +91,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createBitbucketDriver()
     {
-        $config = $this->container['config']['services.bitbucket'];
+        $config = $this->container->make('config')['services.bitbucket'];
 
         return $this->buildProvider(
           BitbucketProvider::class, $config
@@ -105,7 +105,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createGitlabDriver()
     {
-        $config = $this->container['config']['services.gitlab'];
+        $config = $this->container->make('config')['services.gitlab'];
 
         return $this->buildProvider(
             GitlabProvider::class, $config
@@ -122,7 +122,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
     public function buildProvider($provider, $config)
     {
         return new $provider(
-            $this->container['request'], $config['client_id'],
+            $this->container->make('request'), $config['client_id'],
             $config['client_secret'], $this->formatRedirectUrl($config),
             Arr::get($config, 'guzzle', [])
         );
@@ -135,10 +135,10 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createTwitterDriver()
     {
-        $config = $this->container['config']['services.twitter'];
+        $config = $this->container->make('config')['services.twitter'];
 
         return new TwitterProvider(
-            $this->container['request'], new TwitterServer($this->formatConfig($config))
+            $this->container->make('request'), new TwitterServer($this->formatConfig($config))
         );
     }
 
@@ -168,7 +168,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
         $redirect = value($config['redirect']);
 
         return Str::startsWith($redirect, '/')
-                    ? $this->container['url']->to($redirect)
+                    ? $this->container->make('url')->to($redirect)
                     : $redirect;
     }
 


### PR DESCRIPTION
Removed array access on the container instance in SocialiteManger.php. The concrete class implements ArrayAccess, but the type hinted interface does not.
<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
