### PR TITLE
[5.x] Add custom exceptions for providers of One

### DIFF
--- a/src/One/AbstractProvider.php
+++ b/src/One/AbstractProvider.php
@@ -4,7 +4,6 @@ namespace Laravel\Socialite\One;
 
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use InvalidArgumentException;
 use Laravel\Socialite\Contracts\Provider as ProviderContract;
 use League\OAuth1\Client\Credentials\TokenCredentials;
 use League\OAuth1\Client\Server\Server;
@@ -64,12 +63,12 @@ abstract class AbstractProvider implements ProviderContract
      *
      * @return \Laravel\Socialite\One\User
      *
-     * @throws \InvalidArgumentException
+     * @throws \Laravel\Socialite\One\MissingVerifierException
      */
     public function user()
     {
         if (! $this->hasNecessaryVerifier()) {
-            throw new InvalidArgumentException('Invalid request. Missing OAuth verifier.');
+            throw new MissingVerifierException('Invalid request. Missing OAuth verifier.');
         }
 
         $token = $this->getToken();

--- a/src/One/AbstractProvider.php
+++ b/src/One/AbstractProvider.php
@@ -128,6 +128,10 @@ abstract class AbstractProvider implements ProviderContract
     {
         $temp = $this->request->session()->get('oauth.temp');
 
+        if (! $temp) {
+            throw new MissingTemporaryCredentialsException('Missing temporary OAuth credentials.');
+        }
+
         return $this->server->getTokenCredentials(
             $temp, $this->request->get('oauth_token'), $this->request->get('oauth_verifier')
         );

--- a/src/One/MissingTemporaryCredentialsException.php
+++ b/src/One/MissingTemporaryCredentialsException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Socialite\One;
+
+use InvalidArgumentException;
+
+class MissingTemporaryCredentialsException extends InvalidArgumentException
+{
+    //
+}

--- a/src/One/MissingVerifierException.php
+++ b/src/One/MissingVerifierException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Socialite\One;
+
+use InvalidArgumentException;
+
+class MissingVerifierException extends InvalidArgumentException
+{
+    //
+}

--- a/src/One/TwitterProvider.php
+++ b/src/One/TwitterProvider.php
@@ -2,8 +2,6 @@
 
 namespace Laravel\Socialite\One;
 
-use InvalidArgumentException;
-
 class TwitterProvider extends AbstractProvider
 {
     /**
@@ -12,7 +10,7 @@ class TwitterProvider extends AbstractProvider
     public function user()
     {
         if (! $this->hasNecessaryVerifier()) {
-            throw new InvalidArgumentException('Invalid request. Missing OAuth verifier.');
+            throw new MissingVerifierException('Invalid request. Missing OAuth verifier.');
         }
 
         $user = $this->server->getUserDetails($token = $this->getToken(), $this->shouldBypassCache($token->getIdentifier(), $token->getSecret()));

--- a/tests/OAuthOneTest.php
+++ b/tests/OAuthOneTest.php
@@ -5,7 +5,7 @@ namespace Laravel\Socialite\Tests;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use InvalidArgumentException;
+use Laravel\Socialite\One\MissingVerifierException;
 use Laravel\Socialite\One\User as SocialiteUser;
 use Laravel\Socialite\Tests\Fixtures\OAuthOneTestProviderStub;
 use League\OAuth1\Client\Credentials\TemporaryCredentials;
@@ -69,7 +69,7 @@ class OAuthOneTest extends TestCase
 
     public function testExceptionIsThrownWhenVerifierIsMissing()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(MissingVerifierException::class);
 
         $server = m::mock(Twitter::class);
         $request = Request::create('foo');

--- a/tests/OAuthOneTest.php
+++ b/tests/OAuthOneTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Socialite\Tests;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Laravel\Socialite\One\MissingTemporaryCredentialsException;
 use Laravel\Socialite\One\MissingVerifierException;
 use Laravel\Socialite\One\User as SocialiteUser;
 use Laravel\Socialite\Tests\Fixtures\OAuthOneTestProviderStub;
@@ -74,6 +75,19 @@ class OAuthOneTest extends TestCase
         $server = m::mock(Twitter::class);
         $request = Request::create('foo');
         $request->setLaravelSession($session = m::mock(Session::class));
+
+        $provider = new OAuthOneTestProviderStub($request, $server);
+        $provider->user();
+    }
+
+    public function testExceptionIsThrownWhenTemporaryCredentialsAreMissing()
+    {
+        $this->expectException(MissingTemporaryCredentialsException::class);
+
+        $server = m::mock(Twitter::class);
+        $request = Request::create('foo', 'GET', ['oauth_token' => 'oauth_token', 'oauth_verifier' => 'oauth_verifier']);
+        $request->setLaravelSession($session = m::mock(Session::class));
+        $session->shouldReceive('get')->once()->with('oauth.temp')->andReturn(null);
 
         $provider = new OAuthOneTestProviderStub($request, $server);
         $provider->user();


### PR DESCRIPTION
<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

For more error controllability.

Also `Symfony\Component\Debug\Exception\FatalThrowableError` is thrown when temporary credentials are missing.

> Argument 1 passed to League\OAuth1\Client\Server\Server::getTokenCredentials() must be an instance of League\OAuth1\Client\Credentials\TemporaryCredentials, null given, called in /var/www/vendor/laravel/socialite/src/One/AbstractProvider.php on line 133
