### PR TITLE
[4.x] Changes the description of the buildAuthUrlFromBase() method

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -156,7 +156,7 @@ abstract class AbstractProvider implements ProviderContract
     }
 
     /**
-     * Build the authentication URL for the provider from base.
+     * Build the authentication URL for the provider from the given base URL.
      *
      * @param  string  $url
      * @param  string  $state

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -156,7 +156,7 @@ abstract class AbstractProvider implements ProviderContract
     }
 
     /**
-     * Get the authentication URL for the provider.
+     * Build the authentication URL for the provider from base.
      *
      * @param  string  $url
      * @param  string  $state


### PR DESCRIPTION
This change corrects the description of the [`buildAuthUrlFromBase()`](https://github.com/laravel/socialite/blob/4.0/src/Two/AbstractProvider.php#L165) method in [`Laravel\Socialite\Two\AbstractProvider`](https://github.com/laravel/socialite/blob/4.0/src/Two/AbstractProvider.php).

Previously, this description was duplicated with that of the [`getAuthUrl()`](https://github.com/laravel/socialite/blob/4.0/src/Two/AbstractProvider.php#L132) method.