### PR TITLE
[4.x] Remove guzzlehttp/guzzle ~5.0 workaround

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -3,7 +3,6 @@
 namespace Laravel\Socialite\Two;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\ClientInterface;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
@@ -258,11 +257,9 @@ abstract class AbstractProvider implements ProviderContract
      */
     public function getAccessTokenResponse($code)
     {
-        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
-
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers' => ['Accept' => 'application/json'],
-            $postKey => $this->getTokenFields($code),
+            'form_params' => $this->getTokenFields($code),
         ]);
 
         return json_decode($response->getBody(), true);

--- a/src/Two/BitbucketProvider.php
+++ b/src/Two/BitbucketProvider.php
@@ -3,7 +3,6 @@
 namespace Laravel\Socialite\Two;
 
 use Exception;
-use GuzzleHttp\ClientInterface;
 use Illuminate\Support\Arr;
 
 class BitbucketProvider extends AbstractProvider implements ProviderInterface
@@ -103,12 +102,10 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
      */
     public function getAccessToken($code)
     {
-        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
-
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'auth' => [$this->clientId, $this->clientSecret],
             'headers' => ['Accept' => 'application/json'],
-            $postKey => $this->getTokenFields($code),
+            'form_params' => $this->getTokenFields($code),
         ]);
 
         return json_decode($response->getBody(), true)['access_token'];

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Socialite\Two;
 
-use GuzzleHttp\ClientInterface;
 use Illuminate\Support\Arr;
 
 class FacebookProvider extends AbstractProvider implements ProviderInterface
@@ -70,10 +69,8 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      */
     public function getAccessTokenResponse($code)
     {
-        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
-
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            $postKey => $this->getTokenFields($code),
+            'form_params' => $this->getTokenFields($code),
         ]);
 
         $data = json_decode($response->getBody(), true);

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Socialite\Tests;
 
-use GuzzleHttp\ClientInterface;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -45,9 +44,8 @@ class OAuthTwoTest extends TestCase
         $session->shouldReceive('pull')->once()->with('state')->andReturn(str_repeat('A', 40));
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock(stdClass::class);
-        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
         $provider->http->shouldReceive('post')->once()->with('http://token.url', [
-            'headers' => ['Accept' => 'application/json'], $postKey => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
+            'headers' => ['Accept' => 'application/json'], 'form_params' => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
         ])->andReturn($response = m::mock(stdClass::class));
         $response->shouldReceive('getBody')->once()->andReturn('{ "access_token" : "access_token", "refresh_token" : "refresh_token", "expires_in" : 3600 }');
         $user = $provider->user();
@@ -66,9 +64,8 @@ class OAuthTwoTest extends TestCase
         $session->shouldReceive('pull')->once()->with('state')->andReturn(str_repeat('A', 40));
         $provider = new FacebookTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock(stdClass::class);
-        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
         $provider->http->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.3/oauth/access_token', [
-            $postKey => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
+            'form_params' => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
         ])->andReturn($response = m::mock(stdClass::class));
         $response->shouldReceive('getBody')->once()->andReturn(json_encode(['access_token' => 'access_token', 'expires' => 5183085]));
         $user = $provider->user();


### PR DESCRIPTION
There still exists a `"~5.0|~6.0"` workaround for Guzzle 6.0 replacing the `'body'` option with `'form_params'`.

1. Since Socialite 3.0 and Laravel 5.4 (2017 January 15) this package has required Composer dependency:
   ```
   "guzzlehttp/guzzle": "~6.0",
   ```
   * https://github.com/laravel/socialite/commit/811a7446d869dfdd9625cdfb3fa0b70207805eb2#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780
   * Only the `'form_params'` key is used so the Guzzle 5 `'body'` key fallback can be removed.
2. `"guzzlehttp/guzzle"` 7.x **removes** the `GuzzleHttp\ClientInterface::VERSION` property being used to select which Guzzle option key to use.
   * https://github.com/guzzle/guzzle/blob/master/UPGRADING.md#60-to-70

This removes code no longer called that will cause issues when dependencies are updated to `"guzzlehttp/guzzle": "^6.3|^7.0"` like `"laravel/framework"`'s 6.x & 7.x branches have configured.

> Sidenote: I think this package's Guzzle dependencies can't be bumped until "league/oauth1-client" version bumps to v7 first.