### PR TITLE
[5.x] include grant_type=authorization code in token request parameters

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -274,6 +274,7 @@ abstract class AbstractProvider implements ProviderContract
     protected function getTokenFields($code)
     {
         return [
+            'grant_type' => 'authorization_code',
             'client_id' => $this->clientId,
             'client_secret' => $this->clientSecret,
             'code' => $code,

--- a/src/Two/BitbucketProvider.php
+++ b/src/Two/BitbucketProvider.php
@@ -110,15 +110,4 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
 
         return json_decode($response->getBody(), true)['access_token'];
     }
-
-    /**
-     * Get the POST fields for the token request.
-     *
-     * @param  string  $code
-     * @return array
-     */
-    protected function getTokenFields($code)
-    {
-        return parent::getTokenFields($code) + ['grant_type' => 'authorization_code'];
-    }
 }

--- a/src/Two/GitlabProvider.php
+++ b/src/Two/GitlabProvider.php
@@ -54,12 +54,4 @@ class GitlabProvider extends AbstractProvider implements ProviderInterface
             'avatar' => $user['avatar_url'],
         ]);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTokenFields($code)
-    {
-        return parent::getTokenFields($code) + ['grant_type' => 'authorization_code'];
-    }
 }

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -41,19 +41,6 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     }
 
     /**
-     * Get the POST fields for the token request.
-     *
-     * @param  string  $code
-     * @return array
-     */
-    protected function getTokenFields($code)
-    {
-        return Arr::add(
-            parent::getTokenFields($code), 'grant_type', 'authorization_code'
-        );
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function getUserByToken($token)

--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -37,17 +37,6 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
     }
 
     /**
-     * Get the POST fields for the token request.
-     *
-     * @param  string  $code
-     * @return array
-     */
-    protected function getTokenFields($code)
-    {
-        return parent::getTokenFields($code) + ['grant_type' => 'authorization_code'];
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function getUserByToken($token)

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -45,7 +45,7 @@ class OAuthTwoTest extends TestCase
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock(stdClass::class);
         $provider->http->shouldReceive('post')->once()->with('http://token.url', [
-            'headers' => ['Accept' => 'application/json'], 'form_params' => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
+            'headers' => ['Accept' => 'application/json'], 'form_params' => ['grant_type' => 'authorization_code', 'client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
         ])->andReturn($response = m::mock(stdClass::class));
         $response->shouldReceive('getBody')->once()->andReturn('{ "access_token" : "access_token", "refresh_token" : "refresh_token", "expires_in" : 3600 }');
         $user = $provider->user();
@@ -65,7 +65,7 @@ class OAuthTwoTest extends TestCase
         $provider = new FacebookTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock(stdClass::class);
         $provider->http->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.3/oauth/access_token', [
-            'form_params' => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
+            'form_params' => ['grant_type' => 'authorization_code', 'client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
         ])->andReturn($response = m::mock(stdClass::class));
         $response->shouldReceive('getBody')->once()->andReturn(json_encode(['access_token' => 'access_token', 'expires' => 5183085]));
         $user = $provider->user();


### PR DESCRIPTION
This is a PR to close #484. This adds `grant_type=authorization_code` to the parameters in a token request, to bring it in line with the OAuth 2 spec.

I believe this should be added to the current 5.x branch, as this is somewhere between a bug fix and a backwards compatible change. Given that the majority of the socialite provider plugins have to add this parameter anyway, this will allow them to drop the override in the future but won't have any negative effects if they update to this code either.