### PR TITLE
Facebook tokenless picture endpoint fix

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -49,6 +49,13 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     protected $reRequest = false;
 
     /**
+     * User access token.
+     *
+     * @var string|null
+     */
+    private $fbAccesToken;
+
+    /**
      * {@inheritdoc}
      */
     protected function getAuthUrl($state)
@@ -83,6 +90,8 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
+        $this->fbAccesToken = $token;
+
         $meUrl = $this->graphUrl.'/'.$this->version.'/me?access_token='.$token.'&fields='.implode(',', $this->fields);
 
         if (! empty($this->clientSecret)) {
@@ -105,15 +114,15 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user)
     {
-        $avatarUrl = $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture';
+        $avatarUrl = $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture?access_token=' . $this->fbAccesToken;
 
         return (new User)->setRaw($user)->map([
             'id' => $user['id'],
             'nickname' => null,
             'name' => $user['name'] ?? null,
             'email' => $user['email'] ?? null,
-            'avatar' => $avatarUrl.'?type=normal',
-            'avatar_original' => $avatarUrl.'?width=1920',
+            'avatar' => $avatarUrl.'&type=normal',
+            'avatar_original' => $avatarUrl.'&width=1920',
             'profileUrl' => $user['link'] ?? null,
         ]);
     }

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -114,7 +114,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user)
     {
-        $avatarUrl = $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture?access_token=' . $this->fbAccesToken;
+        $avatarUrl = $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture?access_token='.$this->fbAccesToken;
 
         return (new User)->setRaw($user)->map([
             'id' => $user['id'],


### PR DESCRIPTION
This PR is a fix to issue #487. 

According to Facebook announcement (https://developers.facebook.com/blog/post/2020/08/04/Introducing-graph-v8-marketing-api-v8), picture endpoint without `access_token` query param will not return user picture anymore by October 24, 2020.