### PR TITLE
[5.x] Added merge of parameters to getTokenFields

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -273,13 +273,15 @@ abstract class AbstractProvider implements ProviderContract
      */
     protected function getTokenFields($code)
     {
-        return [
+        $fields = [
             'grant_type' => 'authorization_code',
             'client_id' => $this->clientId,
             'client_secret' => $this->clientSecret,
             'code' => $code,
             'redirect_uri' => $this->redirectUrl,
         ];
+
+        return array_merge($fields, $this->parameters);
     }
 
     /**


### PR DESCRIPTION
This allows token fields to be overridden at runtime for methods like user() the same way as the initial redirect(). Currently redirect_uri will throw an error when fetching user data with: Socialite::driver($driver)->with(['redirect_uri' => $redirect])->user()