### PR TITLE
[5.x] Cache User instance to allow $provider->user() to be called multiple times

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -89,9 +89,9 @@ abstract class AbstractProvider implements ProviderContract
     protected $guzzle = [];
 
     /**
-     * Cached user instance for the authenticated user.
+     * The cached user instance.
      *
-     * @var User|null
+     * @var \Laravel\Socialite\Two\User|null
      */
     protected $user;
 

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -89,6 +89,13 @@ abstract class AbstractProvider implements ProviderContract
     protected $guzzle = [];
 
     /**
+     * Cached user instance for the authenticated user.
+     *
+     * @var User|null
+     */
+    protected $user;
+
+    /**
      * Create a new provider instance.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -205,17 +212,21 @@ abstract class AbstractProvider implements ProviderContract
      */
     public function user()
     {
+        if ($this->user) {
+            return $this->user;
+        }
+
         if ($this->hasInvalidState()) {
             throw new InvalidStateException;
         }
 
         $response = $this->getAccessTokenResponse($this->getCode());
 
-        $user = $this->mapUserToObject($this->getUserByToken(
+        $this->user = $this->mapUserToObject($this->getUserByToken(
             $token = Arr::get($response, 'access_token')
         ));
 
-        return $user->setToken($token)
+        return $this->user->setToken($token)
                     ->setRefreshToken(Arr::get($response, 'refresh_token'))
                     ->setExpiresIn(Arr::get($response, 'expires_in'));
     }

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -55,6 +55,7 @@ class OAuthTwoTest extends TestCase
         $this->assertSame('access_token', $user->token);
         $this->assertSame('refresh_token', $user->refreshToken);
         $this->assertSame(3600, $user->expiresIn);
+        $this->assertSame($user->id, $provider->user()->id);
     }
 
     public function testUserReturnsAUserInstanceForTheAuthenticatedFacebookRequest()
@@ -75,6 +76,7 @@ class OAuthTwoTest extends TestCase
         $this->assertSame('access_token', $user->token);
         $this->assertNull($user->refreshToken);
         $this->assertSame(5183085, $user->expiresIn);
+        $this->assertSame($user->id, $provider->user()->id);
     }
 
     public function testExceptionIsThrownIfStateIsInvalid()


### PR DESCRIPTION
This allows `$provider->user()` to be called multiple times. Handy if you want to call it in a form request to do some validation before accessing it in the controller. More info: #490.