### PR TITLE
Add getRaw method to the User contract

### DIFF
--- a/src/AbstractUser.php
+++ b/src/AbstractUser.php
@@ -50,9 +50,7 @@ abstract class AbstractUser implements ArrayAccess, User
     public $user;
 
     /**
-     * Get the unique identifier for the user.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getId()
     {
@@ -60,9 +58,7 @@ abstract class AbstractUser implements ArrayAccess, User
     }
 
     /**
-     * Get the nickname / username for the user.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getNickname()
     {
@@ -70,9 +66,7 @@ abstract class AbstractUser implements ArrayAccess, User
     }
 
     /**
-     * Get the full name of the user.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getName()
     {
@@ -80,9 +74,7 @@ abstract class AbstractUser implements ArrayAccess, User
     }
 
     /**
-     * Get the e-mail address of the user.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getEmail()
     {
@@ -90,9 +82,7 @@ abstract class AbstractUser implements ArrayAccess, User
     }
 
     /**
-     * Get the avatar / image URL for the user.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function getAvatar()
     {
@@ -100,9 +90,7 @@ abstract class AbstractUser implements ArrayAccess, User
     }
 
     /**
-     * Get the raw user array.
-     *
-     * @return array
+     * {@inheritDoc}
      */
     public function getRaw()
     {

--- a/src/Contracts/User.php
+++ b/src/Contracts/User.php
@@ -38,4 +38,11 @@ interface User
      * @return string
      */
     public function getAvatar();
+
+    /**
+     * Get the raw user array.
+     *
+     * @return array
+     */
+    public function getRaw();
 }


### PR DESCRIPTION
Hey,

```php
use Laravel\Socialite\Contracts\User as SocialiteUser;

class LoginRequest extends FormRequest
{
    public function authorize()
    {
        return with(Socialite::driver('google')->user(), function (SocialiteUser $user) {
            return $user->getRaw()['hd'] === 'myorg.com';
        });
    }
}
```

I can use the public method `getRaw` on `AbstractUser` to get additional information about the user like in the case of Google his organization name but when using type hinting and static analysis (shout-out to Larastan 🚀) I get an error about accessing undefined method.

Can we add getRaw to the `Socialite\Contracts\User` contract?