### PR TITLE
[5.x] Revert Facebook picture access token changes

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -114,15 +114,15 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user)
     {
-        $avatarUrl = $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture?access_token='.$this->lastToken;
+        $avatarUrl = $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture';
 
         return (new User)->setRaw($user)->map([
             'id' => $user['id'],
             'nickname' => null,
             'name' => $user['name'] ?? null,
             'email' => $user['email'] ?? null,
-            'avatar' => $avatarUrl.'&type=normal',
-            'avatar_original' => $avatarUrl.'&width=1920',
+            'avatar' => $avatarUrl.'?type=normal',
+            'avatar_original' => $avatarUrl.'?width=1920',
             'profileUrl' => $user['link'] ?? null,
         ]);
     }

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -146,6 +146,16 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     }
 
     /**
+     * Get the last access token used.
+     *
+     * @return string|null
+     */
+    public function lastToken()
+    {
+        return $this->lastToken;
+    }
+
+    /**
      * Set the user fields to request from Facebook.
      *
      * @param  array  $fields

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -146,16 +146,6 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     }
 
     /**
-     * Get the last access token used.
-     *
-     * @return string|null
-     */
-    public function lastToken()
-    {
-        return $this->lastToken;
-    }
-
-    /**
      * Set the user fields to request from Facebook.
      *
      * @param  array  $fields
@@ -190,6 +180,16 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
         $this->reRequest = true;
 
         return $this;
+    }
+
+    /**
+     * Get the last access token used.
+     *
+     * @return string|null
+     */
+    public function lastToken()
+    {
+        return $this->lastToken;
     }
 
     /**


### PR DESCRIPTION
This reverts https://github.com/laravel/socialite/pull/489 which causes the `access_token` to be exposed to the outside when the picture url is directly served on a webpage. This can lead malicious third parties to make use of said access token and exploit it by making requests on behalf of the Facebook App. In light of this we've decided to revert these changes completely.

Since there's no way at moment anymore to do any tokenless requests to retrieve the Facebook picture only API requests with a token can be made. These need to be built by app developers themselves from now on and hidden behind a custom route in their app in order to serve the picture in a secure fashion. It's very unfortunate that Facebook made these changes but it's out of our hands unfortunately.

I've decided to leave the `lastToken` property in place so it can at least still be used if needed. I've also added an `lastToken` method to retrieve it if the app developer needs it.