### PR TITLE
[5.x] Fix Gitlab provider auth url with scopes

### DIFF
--- a/src/Two/GitlabProvider.php
+++ b/src/Two/GitlabProvider.php
@@ -12,11 +12,27 @@ class GitlabProvider extends AbstractProvider implements ProviderInterface
     protected $scopes = ['read_user'];
 
     /**
+     * The separating character for the requested scopes.
+     *
+     * @var string
+     */
+    protected $scopeSeparator = '+';
+
+    /**
      * {@inheritdoc}
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase('https://gitlab.com/oauth/authorize', $state);
+        $url = 'https://gitlab.com/oauth/authorize?';
+
+        $fields = $this->getCodeFields($state);
+        if (! empty($fields['scope'])) {
+            // Gitlab scopes should not be urlencoded
+            $url .= 'scope='.$fields['scope'].'&';
+            unset($fields['scope']);
+        }
+
+        return $url.http_build_query($fields, '', '&', $this->encodingType);
     }
 
     /**


### PR DESCRIPTION
This PR is a proposal to fix #507 

When defining scopes with Gitlab provider not working because of an incorrect URL parameter format.

The Gitlab scope separator should be `+` and not `,` like it is by default.

But there is a second problem. The `+` character is transformed into `%2B` when the URL is created by `http_build_query`.