### PR TITLE
[5.x] Added support for self hosted Gitlab instances

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -109,7 +109,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
 
         return $this->buildProvider(
             GitlabProvider::class, $config
-        )->setHost(Arr::get($config, 'host'));
+        )->setHost($config['host'] ?? null);
     }
 
     /**

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -109,7 +109,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
 
         return $this->buildProvider(
             GitlabProvider::class, $config
-        );
+        )->setHost(Arr::get($config, 'host'));
     }
 
     /**

--- a/src/Two/GitlabProvider.php
+++ b/src/Two/GitlabProvider.php
@@ -12,11 +12,29 @@ class GitlabProvider extends AbstractProvider implements ProviderInterface
     protected $scopes = ['read_user'];
 
     /**
+     * @var string
+     */
+    protected $host = 'https://gitlab.com';
+
+    /**
+     * @param string|null $host
+     * @return $this
+     */
+    public function setHost($host)
+    {
+        if (! empty($host)) {
+            $this->host = rtrim($host, '/');
+        }
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase('https://gitlab.com/oauth/authorize', $state);
+        return $this->buildAuthUrlFromBase($this->host.'/oauth/authorize', $state);
     }
 
     /**
@@ -24,7 +42,7 @@ class GitlabProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getTokenUrl()
     {
-        return 'https://gitlab.com/oauth/token';
+        return $this->host.'/oauth/token';
     }
 
     /**
@@ -32,7 +50,7 @@ class GitlabProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $userUrl = 'https://gitlab.com/api/v3/user?access_token='.$token;
+        $userUrl = $this->host.'/api/v3/user?access_token='.$token;
 
         $response = $this->getHttpClient()->get($userUrl);
 

--- a/src/Two/GitlabProvider.php
+++ b/src/Two/GitlabProvider.php
@@ -12,12 +12,16 @@ class GitlabProvider extends AbstractProvider implements ProviderInterface
     protected $scopes = ['read_user'];
 
     /**
+     * The Gitlab instance host.
+     *
      * @var string
      */
     protected $host = 'https://gitlab.com';
 
     /**
-     * @param string|null $host
+     * Set the Gitlab instance host.
+     *
+     * @param  string|null  $host
      * @return $this
      */
     public function setHost($host)


### PR DESCRIPTION
As discussed in https://github.com/laravel/socialite/issues/509, the current Gitlab driver only supports Gitlab.com. These changes add support for self hosted instances of Gitlab.