### PR TITLE
Fix scope separator in Gitlab provider

### DIFF
--- a/src/Two/GitlabProvider.php
+++ b/src/Two/GitlabProvider.php
@@ -12,6 +12,13 @@ class GitlabProvider extends AbstractProvider implements ProviderInterface
     protected $scopes = ['read_user'];
 
     /**
+     * The separating character for the requested scopes.
+     *
+     * @var string
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
      * The Gitlab instance host.
      *
      * @var string


### PR DESCRIPTION
This PR should fix issue #507 in a proper way than #508 

Defining scopes with Gitlab provider not working because of an incorrect URL parameter format.

In the URL, scopes should be separated by `+` which correspond to ` ` (space character) in a URL encoded format.

This problem occurred only when more than two scopes are specified.
