### PR TITLE
Dynamic Values on Token Requests

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -284,13 +284,13 @@ abstract class AbstractProvider implements ProviderContract
      */
     protected function getTokenFields($code)
     {
-        return [
+        return array_merge([
             'grant_type' => 'authorization_code',
             'client_id' => $this->clientId,
             'client_secret' => $this->clientSecret,
             'code' => $code,
             'redirect_uri' => $this->redirectUrl,
-        ];
+        ], $this->parameters);
     }
 
     /**


### PR DESCRIPTION
Allow token requests to also use provided parameters. 

I came across this issue when building an app that needed the ability to dynamically change the redirect url.

On login you can use:
`Socialite::driver('')->with(['redirect_uri' => $redirect_url])->redirect()`

A number of providers require that when you grab the user after logging in, the redirect_uri has to match the one provided to login but currently the system always uses the default redirect_uri. This change allows people to do something like this:

`Socialite::driver('')->with(['redirect_uri' => $redirect_url])->user()`

This would allow people to properly dynamically set the default values on all parts of signing in. The only change is merging the $parameters array with the built array in the same way as what is done on redirect rather than just returning the built array.

