### PR TITLE
[5.x] Add support for OAuth 2.0 PKCE extension

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -475,7 +475,8 @@ abstract class AbstractProvider implements ProviderContract
     {
         $verifier = $this->request->session()->pull('code_verifier');
         $hashed = hash('sha256', $verifier, true);
-        return rtrim(strtr(base64_encode($hashed), '+/', '-_'), '='); // base64-URL-encoding
+
+        return rtrim(strtr(base64_encode($hashed), '+/', '-_'), '=');
     }
 
     protected function getCodeChallengeMethod() 

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -82,6 +82,13 @@ abstract class AbstractProvider implements ProviderContract
     protected $stateless = false;
 
     /**
+     * Indicates if PKCE should be used.
+     *
+     * @var bool
+     */
+    protected $usesPKCE = false;
+
+    /**
      * The custom Guzzle configuration options.
      *
      * @var array
@@ -158,6 +165,10 @@ abstract class AbstractProvider implements ProviderContract
             $this->request->session()->put('state', $state = $this->getState());
         }
 
+        if ($this->usesPKCE()) {
+            $this->request->session()->put('code_verifier', $codeVerifier = $this->getCodeVerifier());
+        }
+
         return new RedirectResponse($this->getAuthUrl($state));
     }
 
@@ -190,6 +201,11 @@ abstract class AbstractProvider implements ProviderContract
 
         if ($this->usesState()) {
             $fields['state'] = $state;
+        }
+
+        if ($this->usesPKCE()) {
+            $fields['code_challenge'] = $this->getCodeChallenge();
+            $fields['code_challenge_method'] = $this->getCodeChallengeMethod();
         }
 
         return array_merge($fields, $this->parameters);
@@ -284,13 +300,19 @@ abstract class AbstractProvider implements ProviderContract
      */
     protected function getTokenFields($code)
     {
-        return [
+        $fields = [
             'grant_type' => 'authorization_code',
             'client_id' => $this->clientId,
             'client_secret' => $this->clientSecret,
             'code' => $code,
             'redirect_uri' => $this->redirectUrl,
         ];
+
+        if ($this->usesPKCE()) {
+            $field['code_verifier'] = $this->request->session()->pull('code_verifier');
+        }
+
+        return $fields;
     }
 
     /**
@@ -434,6 +456,32 @@ abstract class AbstractProvider implements ProviderContract
         return Str::random(40);
     }
 
+    /**
+     * Determine if the provider uses PKCE.
+     *
+     * @return bool
+     */
+    protected function usesPKCE()
+    {
+        return $this->usesPKCE;
+    }
+
+    protected function getCodeVerifier()
+    {
+        return Str::random(96);
+    }
+
+    protected function getCodeChallenge() 
+    {
+        $verifier = $this->request->session()->pull('code_verifier');
+        $hashed = hash('sha256', $verifier, true);
+        return rtrim(strtr(base64_encode($hashed), '+/', '-_'), '='); // base64-URL-encoding
+    }
+
+    protected function getCodeChallengeMethod() 
+    {
+        return 'S256';
+    }
     /**
      * Set the custom parameters of the request.
      *

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -466,12 +466,22 @@ abstract class AbstractProvider implements ProviderContract
         return $this->usesPKCE;
     }
 
+    /**
+     * Generates a random string of the right length for the PKCE code verifier.
+     *
+     * @return string
+     */
     protected function getCodeVerifier()
     {
         return Str::random(96);
     }
 
-    protected function getCodeChallenge() 
+    /**
+     * Generates the PKCE code challenge based on the PKCE code verifier in the session.
+     *
+     * @return string
+     */
+    protected function getCodeChallenge()
     {
         $verifier = $this->request->session()->pull('code_verifier');
         $hashed = hash('sha256', $verifier, true);
@@ -479,10 +489,16 @@ abstract class AbstractProvider implements ProviderContract
         return rtrim(strtr(base64_encode($hashed), '+/', '-_'), '=');
     }
 
-    protected function getCodeChallengeMethod() 
+    /**
+     * Returns the hash method used to calculate the PKCE code challenge
+     *
+     * @return string
+     */
+    protected function getCodeChallengeMethod()
     {
         return 'S256';
     }
+
     /**
      * Set the custom parameters of the request.
      *

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -14,6 +14,13 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     protected $scopeSeparator = ' ';
 
     /**
+     * Indicates if PKCE should be used.
+     *
+     * @var bool
+     */
+    protected $usesPKCE = true;
+
+    /**
      * The scopes being requested.
      *
      * @var array

--- a/tests/Fixtures/OAuthTwoTestProviderStub.php
+++ b/tests/Fixtures/OAuthTwoTestProviderStub.php
@@ -16,7 +16,7 @@ class OAuthTwoTestProviderStub extends AbstractProvider
 
     protected function getAuthUrl($state)
     {
-        return 'http://auth.url';
+        return $this->buildAuthUrlFromBase('http://auth.url', $state);
     }
 
     protected function getTokenUrl()

--- a/tests/Fixtures/OAuthTwoWithPKCETestProviderStub.php
+++ b/tests/Fixtures/OAuthTwoWithPKCETestProviderStub.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Socialite\Tests\Fixtures;
+
+class OAuthTwoWithPKCETestProviderStub extends OAuthTwoTestProviderStub 
+{
+	protected $usesPKCE = true;
+}

--- a/tests/Fixtures/OAuthTwoWithPKCETestProviderStub.php
+++ b/tests/Fixtures/OAuthTwoWithPKCETestProviderStub.php
@@ -4,5 +4,5 @@ namespace Laravel\Socialite\Tests\Fixtures;
 
 class OAuthTwoWithPKCETestProviderStub extends OAuthTwoTestProviderStub 
 {
-	protected $usesPKCE = true;
+    protected $usesPKCE = true;
 }

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -31,13 +31,14 @@ class OAuthTwoTest extends TestCase
         $request->setLaravelSession($session = m::mock(Session::class));
 
         $state = null;
-        $closure = function($name, $stateInput) use(&$state) {
-            if($name == 'state') {
+        $closure = function($name, $stateInput) use (&$state) {
+            if ($name === 'state') {
                 $state = $stateInput;
+
                 return true;
-            } else {
-                return false;
             }
+
+            return false;
         };
 
         $session->shouldReceive('put')->once()->withArgs($closure);
@@ -57,20 +58,22 @@ class OAuthTwoTest extends TestCase
         $request->setLaravelSession($session = m::mock(Session::class));
 
         $state = null;
-        $closure = function($name, $value) use(&$state, &$codeVerifier) {
-            if($name == 'state') {
+        $closure = function($name, $value) use (&$state, &$codeVerifier) {
+            if ($name === 'state') {
                 $state = $value;
+
                 return true;
-            } elseif($name == 'code_verifier') {
+            } elseif ($name === 'code_verifier') {
                 self::$codeVerifier = $value;
+
                 return true;
-            } else {
-                return false;
             }
+
+            return false;
         };
 
         $codeVerifierClosure = function($name) {
-            if($name == 'code_verifier') {
+            if ($name === 'code_verifier') {
                 return self::$codeVerifier;
             }
         };

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -58,7 +58,7 @@ class OAuthTwoTest extends TestCase
         $request->setLaravelSession($session = m::mock(Session::class));
 
         $state = null;
-        $closure = function($name, $value) use (&$state, &$codeVerifier) {
+        $sessionPutClosure = function($name, $value) use (&$state) {
             if ($name === 'state') {
                 $state = $value;
 
@@ -72,14 +72,14 @@ class OAuthTwoTest extends TestCase
             return false;
         };
 
-        $codeVerifierClosure = function($name) {
+        $sessionPullClosure = function($name) {
             if ($name === 'code_verifier') {
                 return self::$codeVerifier;
             }
         };
 
-        $session->shouldReceive('put')->twice()->withArgs($closure);
-        $session->shouldReceive('pull')->once()->with('code_verifier')->andReturnUsing($codeVerifierClosure);
+        $session->shouldReceive('put')->twice()->withArgs($sessionPutClosure);
+        $session->shouldReceive('pull')->once()->with('code_verifier')->andReturnUsing($sessionPullClosure);
 
         $provider = new OAuthTwoWithPKCETestProviderStub($request, 'client_id', 'client_secret', 'redirect');
         $response = $provider->redirect();


### PR DESCRIPTION
This PR adds support for the OAuth 2.0 [PKCE](https://oauth.net/2/pkce/) extension, as discussed in #483. This extension is recommended in the latest version of the [OAuth 2.0 Security Best Current Practice](https://oauth.net/2/oauth-best-practice/). 

* Adds the PKCE logic in the core OAuth 2 provider
* Enables PKCE with Google
* Other providers can enable PKCE by setting the new `usesPKCE` property on the provider
* The default value is `false`, which is the safer way to handle backwards compatibility, even though technically OAuth providers are supposed to ignore unknown parameters so it should be theoretically possible to always send the PKCE parameters anyway
