### PR TITLE
[5.x] Make PKCE opt-in

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -467,6 +467,18 @@ abstract class AbstractProvider implements ProviderContract
     }
 
     /**
+     * Enables PKCE for the provider.
+     *
+     * @return $this
+     */
+    protected function enablePKCE()
+    {
+        $this->usesPKCE = true;
+
+        return $this;
+    }
+
+    /**
      * Generates a random string of the right length for the PKCE code verifier.
      *
      * @return string

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -25,13 +25,6 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     ];
 
     /**
-     * Indicates if PKCE should be used.
-     *
-     * @var bool
-     */
-    protected $usesPKCE = true;
-
-    /**
      * {@inheritdoc}
      */
     protected function getAuthUrl($state)


### PR DESCRIPTION
This makes https://github.com/laravel/socialite/pull/518 opt-in since it seems to be breaking apps using the Google provider in API's.

Fixes https://github.com/laravel/socialite/issues/522