### PR TITLE
[6.x] Make getAuthUrl public

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -127,7 +127,7 @@ abstract class AbstractProvider implements ProviderContract
      * @param  string  $state
      * @return string
      */
-    abstract protected function getAuthUrl($state);
+    abstract public function getAuthUrl($state);
 
     /**
      * Get the token URL for the provider.

--- a/src/Two/BitbucketProvider.php
+++ b/src/Two/BitbucketProvider.php
@@ -24,7 +24,7 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://bitbucket.org/site/oauth2/authorize', $state);
     }

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -58,7 +58,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://www.facebook.com/'.$this->version.'/dialog/oauth', $state);
     }

--- a/src/Two/GithubProvider.php
+++ b/src/Two/GithubProvider.php
@@ -17,7 +17,7 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://github.com/login/oauth/authorize', $state);
     }

--- a/src/Two/GitlabProvider.php
+++ b/src/Two/GitlabProvider.php
@@ -43,7 +43,7 @@ class GitlabProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase($this->host.'/oauth/authorize', $state);
     }

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -27,7 +27,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://accounts.google.com/o/oauth2/auth', $state);
     }

--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -23,7 +23,7 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://www.linkedin.com/oauth/v2/authorization', $state);
     }

--- a/tests/Fixtures/OAuthTwoTestProviderStub.php
+++ b/tests/Fixtures/OAuthTwoTestProviderStub.php
@@ -14,7 +14,7 @@ class OAuthTwoTestProviderStub extends AbstractProvider
      */
     public $http;
 
-    protected function getAuthUrl($state)
+    public function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('http://auth.url', $state);
     }

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -178,4 +178,20 @@ class OAuthTwoTest extends TestCase
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect');
         $provider->user();
     }
+
+    public function testCanGetAuthUrl()
+    {
+        $request = Request::create('foo');
+        $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect');
+        $authUrl = $provider->getAuthUrl(null);
+        $this->assertSame('http://auth.url?client_id=client_id&redirect_uri=redirect&scope=&response_type=code', $authUrl);
+    }
+
+    public function testCanGetStatelessAuthUrl()
+    {
+        $request = Request::create('foo');
+        $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect');
+        $authUrl = $provider->stateless()->getAuthUrl(null);
+        $this->assertSame('http://auth.url?client_id=client_id&redirect_uri=redirect&scope=&response_type=code', $authUrl);
+    }
 }


### PR DESCRIPTION
When using a SPA, you might want to redirect from your frontend.

With this change you can now get the URL for redirection like this:

```
return Socialite::driver($provider)
    ->stateless()
    ->getAuthUrl(null);

```

<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
