### PR TITLE
Adding userFromToken to Provider Interface

### DIFF
--- a/src/Contracts/Provider.php
+++ b/src/Contracts/Provider.php
@@ -16,5 +16,13 @@ interface Provider
      *
      * @return \Laravel\Socialite\Contracts\User
      */
+
     public function user();
+    /**
+     * Get the User instance for the authenticated user by using access token.
+     *
+     * @param  string  $token
+     * @return \Laravel\Socialite\Contracts\User
+     */
+    public function userFromToken($token);
 }


### PR DESCRIPTION
The Provider interface should have `userFromToken` function in it to make it visible for code snippets and fix the annoying IDE error warning 'function not found'.
