### PR TITLE
Handle 'scope' for Twitter Oauth1

### DIFF
--- a/src/One/TwitterProvider.php
+++ b/src/One/TwitterProvider.php
@@ -32,4 +32,15 @@ class TwitterProvider extends AbstractProvider
             'avatar_original' => str_replace('_normal', '', $user->imageUrl),
         ]);
     }
+
+    /**
+     * Overrides the access level an application requests to a users account.
+     *
+     * @param string $scope
+     * @return void
+     */
+    public function scope(string $scope)
+    {
+        $this->server->setApplicationScope($scope);
+    }
 }

--- a/src/One/TwitterProvider.php
+++ b/src/One/TwitterProvider.php
@@ -34,9 +34,9 @@ class TwitterProvider extends AbstractProvider
     }
 
     /**
-     * Overrides the access level an application requests to a users account.
+     * Set the access level the application should request to the user account.
      *
-     * @param string $scope
+     * @param  string  $scope
      * @return void
      */
     public function scope(string $scope)


### PR DESCRIPTION
Hey,
I recently [made a pull request](https://github.com/thephpleague/oauth1-client/pull/138) in the [thephpleague/oauth1-client](https://github.com/thephpleague/oauth1-client) repository to handle the _scope_ for Twitter Oauth1 (with the parameter _x_auth_access_type_).
I use socialite in my app and I need to be able to set this scope manually, so I added a new method in the TwitterProvider.php to handle it.