### PR TITLE
[5.x] Make enablePKCE public

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -471,7 +471,7 @@ abstract class AbstractProvider implements ProviderContract
      *
      * @return $this
      */
-    protected function enablePKCE()
+    public function enablePKCE()
     {
         $this->usesPKCE = true;
 


### PR DESCRIPTION
#523 makes PKCE opt-in. But the `enablePKCE` method is declared as protected. Make it impossible to enable PKCE without extending a Provider. I believe this method is intended to be public.