### PR TITLE
Fix github oauth authorization scope error

### DIFF
--- a/src/Two/GithubProvider.php
+++ b/src/Two/GithubProvider.php
@@ -13,6 +13,13 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
      * @var array
      */
     protected $scopes = ['user:email'];
+    
+    /**
+     * The separating character for the requested scopes.
+     *
+     * @var string
+     */
+    protected $scopeSeparator = ' ';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Fix github oauth authorization scope error

![image](https://user-images.githubusercontent.com/24415888/133937919-aaee81bb-2bff-41c2-8d3c-974084d166d1.png)


[docs](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#redirect-urls)