### PR TITLE
[5.x] Don't use strlen to check $state

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -272,11 +272,8 @@ abstract class AbstractProvider implements ProviderContract
         }
 
         $state = $this->request->session()->pull('state');
-        if ($state === '' || $state === null) {
-            return true;
-        }
 
-        return $this->request->input('state') !== $state;
+        return empty($state) || $this->request->input('state') !== $state;
     }
 
     /**


### PR DESCRIPTION
If $state is null, PHP8.1 will throw a warning with strlen.
`strlen(): Passing null to parameter #1 ($string) of type string is deprecated`.

https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg

<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
