### PR TITLE
[5.x] Stop using legacy mocking syntax.

### DIFF
--- a/tests/LinkedInProviderTest.php
+++ b/tests/LinkedInProviderTest.php
@@ -22,32 +22,32 @@ class LinkedInProviderTest extends TestCase
     public function test_it_can_map_a_user_without_an_email_address()
     {
         $request = m::mock(Request::class);
-        $request->shouldReceive('input')->with('code')->andReturn('fake-code');
+        $request->allows('input')->with('code')->andReturns('fake-code');
 
         $accessTokenResponse = m::mock(ResponseInterface::class);
-        $accessTokenResponse->shouldReceive('getBody')->andReturn(json_encode(['access_token' => 'fake-token']));
+        $accessTokenResponse->allows('getBody')->andReturns(json_encode(['access_token' => 'fake-token']));
 
         $basicProfileResponse = m::mock(ResponseInterface::class);
-        $basicProfileResponse->shouldReceive('getBody')->andReturn(json_encode(['id' => $userId = 1]));
+        $basicProfileResponse->allows('getBody')->andReturns(json_encode(['id' => $userId = 1]));
 
         // Make sure email address response contains no values.
         $emailAddressResponse = m::mock(ResponseInterface::class);
-        $emailAddressResponse->shouldReceive('getBody')->andReturn(json_encode(['elements' => []]));
+        $emailAddressResponse->allows('getBody')->andReturns(json_encode(['elements' => []]));
 
         $guzzle = m::mock(Client::class);
-        $guzzle->shouldReceive('post')->once()->andReturn($accessTokenResponse);
-        $guzzle->shouldReceive('get')->with('https://api.linkedin.com/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))', [
+        $guzzle->expects('post')->andReturns($accessTokenResponse);
+        $guzzle->allows('get')->with('https://api.linkedin.com/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))', [
             'headers' => [
                 'Authorization' => 'Bearer fake-token',
                 'X-RestLi-Protocol-Version' => '2.0.0',
             ],
-        ])->andReturn($basicProfileResponse);
-        $guzzle->shouldReceive('get')->with('https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))', [
+        ])->andReturns($basicProfileResponse);
+        $guzzle->allows('get')->with('https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))', [
             'headers' => [
                 'Authorization' => 'Bearer fake-token',
                 'X-RestLi-Protocol-Version' => '2.0.0',
             ],
-        ])->andReturn($emailAddressResponse);
+        ])->andReturns($emailAddressResponse);
 
         $provider = new LinkedInProvider($request, 'client_id', 'client_secret', 'redirect');
         $provider->stateless();

--- a/tests/OAuthOneTest.php
+++ b/tests/OAuthOneTest.php
@@ -30,11 +30,11 @@ class OAuthOneTest extends TestCase
     {
         $server = m::mock(Twitter::class);
         $temp = m::mock(TemporaryCredentials::class);
-        $server->shouldReceive('getTemporaryCredentials')->once()->andReturn($temp);
-        $server->shouldReceive('getAuthorizationUrl')->once()->with($temp)->andReturn('http://auth.url');
+        $server->expects('getTemporaryCredentials')->andReturns($temp);
+        $server->expects('getAuthorizationUrl')->with($temp)->andReturns('http://auth.url');
         $request = Request::create('foo');
         $request->setLaravelSession($session = m::mock(Session::class));
-        $session->shouldReceive('put')->once()->with('oauth.temp', $temp);
+        $session->expects('put')->with('oauth.temp', $temp);
 
         $provider = new OAuthOneTestProviderStub($request, $server);
         $response = $provider->redirect();
@@ -47,18 +47,18 @@ class OAuthOneTest extends TestCase
     {
         $server = m::mock(Twitter::class);
         $temp = m::mock(TemporaryCredentials::class);
-        $server->shouldReceive('getTokenCredentials')->once()->with($temp, 'oauth_token', 'oauth_verifier')->andReturn(
+        $server->expects('getTokenCredentials')->with($temp, 'oauth_token', 'oauth_verifier')->andReturns(
             $token = m::mock(TokenCredentials::class)
         );
-        $server->shouldReceive('getUserDetails')->once()->with($token, false)->andReturn($user = m::mock(User::class));
-        $token->shouldReceive('getIdentifier')->twice()->andReturn('identifier');
-        $token->shouldReceive('getSecret')->twice()->andReturn('secret');
+        $server->expects('getUserDetails')->with($token, false)->andReturns($user = m::mock(User::class));
+        $token->expects('getIdentifier')->twice()->andReturns('identifier');
+        $token->expects('getSecret')->twice()->andReturns('secret');
         $user->uid = 'uid';
         $user->email = 'foo@bar.com';
         $user->extra = ['extra' => 'extra'];
         $request = Request::create('foo', 'GET', ['oauth_token' => 'oauth_token', 'oauth_verifier' => 'oauth_verifier']);
         $request->setLaravelSession($session = m::mock(Session::class));
-        $session->shouldReceive('get')->once()->with('oauth.temp')->andReturn($temp);
+        $session->expects('get')->with('oauth.temp')->andReturns($temp);
 
         $provider = new OAuthOneTestProviderStub($request, $server);
         $user = $provider->user();
@@ -88,7 +88,7 @@ class OAuthOneTest extends TestCase
         $server = m::mock(Twitter::class);
         $request = Request::create('foo', 'GET', ['oauth_token' => 'oauth_token', 'oauth_verifier' => 'oauth_verifier']);
         $request->setLaravelSession($session = m::mock(Session::class));
-        $session->shouldReceive('get')->once()->with('oauth.temp')->andReturn(null);
+        $session->expects('get')->with('oauth.temp')->andReturns(null);
 
         $provider = new OAuthOneTestProviderStub($request, $server);
         $provider->user();

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -42,7 +42,7 @@ class OAuthTwoTest extends TestCase
             return false;
         };
 
-        $session->shouldReceive('put')->once()->withArgs($closure);
+        $session->expects('put')->withArgs($closure);
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect');
         $response = $provider->redirect();
 
@@ -79,8 +79,8 @@ class OAuthTwoTest extends TestCase
             }
         };
 
-        $session->shouldReceive('put')->twice()->withArgs($sessionPutClosure);
-        $session->shouldReceive('get')->once()->with('code_verifier')->andReturnUsing($sessionPullClosure);
+        $session->expects('put')->twice()->withArgs($sessionPutClosure);
+        $session->expects('get')->with('code_verifier')->andReturnUsing($sessionPullClosure);
 
         $provider = new OAuthTwoWithPKCETestProviderStub($request, 'client_id', 'client_secret', 'redirect');
         $response = $provider->redirect();
@@ -97,14 +97,14 @@ class OAuthTwoTest extends TestCase
         $request = Request::create('foo', 'GET', ['state' => str_repeat('A', 40), 'code' => 'code']);
         $request->setLaravelSession($session = m::mock(Session::class));
         $codeVerifier = Str::random(32);
-        $session->shouldReceive('pull')->once()->with('state')->andReturn(str_repeat('A', 40));
-        $session->shouldReceive('pull')->once()->with('code_verifier')->andReturn($codeVerifier);
+        $session->expects('pull')->with('state')->andReturns(str_repeat('A', 40));
+        $session->expects('pull')->with('code_verifier')->andReturns($codeVerifier);
         $provider = new OAuthTwoWithPKCETestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock(stdClass::class);
-        $provider->http->shouldReceive('post')->once()->with('http://token.url', [
+        $provider->http->expects('post')->with('http://token.url', [
             'headers' => ['Accept' => 'application/json'], 'form_params' => ['grant_type' => 'authorization_code', 'client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri', 'code_verifier' => $codeVerifier],
-        ])->andReturn($response = m::mock(stdClass::class));
-        $response->shouldReceive('getBody')->once()->andReturn('{ "access_token" : "access_token", "refresh_token" : "refresh_token", "expires_in" : 3600 }');
+        ])->andReturns($response = m::mock(stdClass::class));
+        $response->expects('getBody')->andReturns('{ "access_token" : "access_token", "refresh_token" : "refresh_token", "expires_in" : 3600 }');
         $user = $provider->user();
 
         $this->assertInstanceOf(User::class, $user);
@@ -119,13 +119,13 @@ class OAuthTwoTest extends TestCase
     {
         $request = Request::create('foo', 'GET', ['state' => str_repeat('A', 40), 'code' => 'code']);
         $request->setLaravelSession($session = m::mock(Session::class));
-        $session->shouldReceive('pull')->once()->with('state')->andReturn(str_repeat('A', 40));
+        $session->expects('pull')->with('state')->andReturns(str_repeat('A', 40));
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock(stdClass::class);
-        $provider->http->shouldReceive('post')->once()->with('http://token.url', [
+        $provider->http->expects('post')->with('http://token.url', [
             'headers' => ['Accept' => 'application/json'], 'form_params' => ['grant_type' => 'authorization_code', 'client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
-        ])->andReturn($response = m::mock(stdClass::class));
-        $response->shouldReceive('getBody')->once()->andReturn('{ "access_token" : "access_token", "refresh_token" : "refresh_token", "expires_in" : 3600 }');
+        ])->andReturns($response = m::mock(stdClass::class));
+        $response->expects('getBody')->andReturns('{ "access_token" : "access_token", "refresh_token" : "refresh_token", "expires_in" : 3600 }');
         $user = $provider->user();
 
         $this->assertInstanceOf(User::class, $user);
@@ -140,13 +140,13 @@ class OAuthTwoTest extends TestCase
     {
         $request = Request::create('foo', 'GET', ['state' => str_repeat('A', 40), 'code' => 'code']);
         $request->setSession($session = m::mock(SessionInterface::class));
-        $session->shouldReceive('pull')->once()->with('state')->andReturn(str_repeat('A', 40));
+        $session->expects('pull')->with('state')->andReturns(str_repeat('A', 40));
         $provider = new FacebookTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock(stdClass::class);
-        $provider->http->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.3/oauth/access_token', [
+        $provider->http->expects('post')->with('https://graph.facebook.com/v3.3/oauth/access_token', [
             'form_params' => ['grant_type' => 'authorization_code', 'client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
-        ])->andReturn($response = m::mock(stdClass::class));
-        $response->shouldReceive('getBody')->once()->andReturn(json_encode(['access_token' => 'access_token', 'expires' => 5183085]));
+        ])->andReturns($response = m::mock(stdClass::class));
+        $response->expects('getBody')->andReturns(json_encode(['access_token' => 'access_token', 'expires' => 5183085]));
         $user = $provider->user();
 
         $this->assertInstanceOf(User::class, $user);
@@ -163,7 +163,7 @@ class OAuthTwoTest extends TestCase
 
         $request = Request::create('foo', 'GET', ['state' => str_repeat('B', 40), 'code' => 'code']);
         $request->setLaravelSession($session = m::mock(Session::class));
-        $session->shouldReceive('pull')->once()->with('state')->andReturn(str_repeat('A', 40));
+        $session->expects('pull')->with('state')->andReturns(str_repeat('A', 40));
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect');
         $provider->user();
     }
@@ -174,7 +174,7 @@ class OAuthTwoTest extends TestCase
 
         $request = Request::create('foo', 'GET', ['state' => 'state', 'code' => 'code']);
         $request->setLaravelSession($session = m::mock(Session::class));
-        $session->shouldReceive('pull')->once()->with('state');
+        $session->expects('pull')->with('state');
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect');
         $provider->user();
     }


### PR DESCRIPTION
<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Stop using legacy mocking syntax, and uses `expects` and `andReturns`.