### PR TITLE
Fixed DocBlock return type

### DIFF
--- a/src/Contracts/Provider.php
+++ b/src/Contracts/Provider.php
@@ -7,7 +7,7 @@ interface Provider
     /**
      * Redirect the user to the authentication page for the provider.
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function redirect();
 

--- a/src/Contracts/Provider.php
+++ b/src/Contracts/Provider.php
@@ -7,7 +7,7 @@ interface Provider
     /**
      * Redirect the user to the authentication page for the provider.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Illuminate\Http\RedirectResponse
      */
     public function redirect();
 


### PR DESCRIPTION
Need this DocBlock fix so that IDEs didn't complain when we type-hint our extensions and implementations.