### PR TITLE
Add Spotify Provider

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -13,6 +13,7 @@ use Laravel\Socialite\Two\GithubProvider;
 use Laravel\Socialite\Two\GitlabProvider;
 use Laravel\Socialite\Two\GoogleProvider;
 use Laravel\Socialite\Two\LinkedInProvider;
+use Laravel\Socialite\Two\SpotifyProvider;
 use League\OAuth1\Client\Server\Twitter as TwitterServer;
 
 class SocialiteManager extends Manager implements Contracts\Factory
@@ -110,6 +111,20 @@ class SocialiteManager extends Manager implements Contracts\Factory
         return $this->buildProvider(
             GitlabProvider::class, $config
         )->setHost($config['host'] ?? null);
+    }
+
+    /**
+     * Create an instance of the specified driver.
+     *
+     * @return \Laravel\Socialite\Two\AbstractProvider
+     */
+    protected function createSpotifyDriver()
+    {
+        $config = $this->config->get('services.spotify');
+
+        return $this->buildProvider(
+          SpotifyProvider::class, $config
+        );
     }
 
     /**

--- a/src/Two/SpotifyProvider.php
+++ b/src/Two/SpotifyProvider.php
@@ -44,7 +44,7 @@ class SpotifyProvider extends AbstractProvider implements ProviderInterface
 
         $response = $this->getHttpClient()->get('https://api.spotify.com/v1/me', [
             'headers' => [
-                'Authorization' => 'Bearer ' . $token
+                'Authorization' => 'Bearer '.$token
             ]
         ]);
 

--- a/src/Two/SpotifyProvider.php
+++ b/src/Two/SpotifyProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Laravel\Socialite\Two;
+
+use Illuminate\Support\Arr;
+
+class SpotifyProvider extends AbstractProvider implements ProviderInterface
+{
+    /**
+     * The scopes being requested.
+     *
+     * @var array
+     */
+    protected $scopes = ['user-read-private', 'user-read-email'];
+
+    /**
+     * The separating character for the requested scopes.
+     *
+     * @var string
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://accounts.spotify.com/authorize', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://accounts.spotify.com/api/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+
+        $response = $this->getHttpClient()->get('https://api.spotify.com/v1/me', [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token
+            ]
+        ]);
+
+        return (array) json_decode($response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id' => $user['id'],
+            'name' => $user['display_name'],
+            'email' => $user['email'],
+            'avatar' => Arr::get($user, 'images.0.url'),
+            'avatar_original' => Arr::get($user, 'images.0.url'),
+        ]);
+    }
+}

--- a/src/Two/SpotifyProvider.php
+++ b/src/Two/SpotifyProvider.php
@@ -41,7 +41,6 @@ class SpotifyProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-
         $response = $this->getHttpClient()->get('https://api.spotify.com/v1/me', [
             'headers' => [
                 'Authorization' => 'Bearer '.$token,

--- a/src/Two/SpotifyProvider.php
+++ b/src/Two/SpotifyProvider.php
@@ -44,7 +44,7 @@ class SpotifyProvider extends AbstractProvider implements ProviderInterface
 
         $response = $this->getHttpClient()->get('https://api.spotify.com/v1/me', [
             'headers' => [
-                'Authorization' => 'Bearer '.$token
+                'Authorization' => 'Bearer '.$token,
             ]
         ]);
 

--- a/src/Two/SpotifyProvider.php
+++ b/src/Two/SpotifyProvider.php
@@ -45,7 +45,7 @@ class SpotifyProvider extends AbstractProvider implements ProviderInterface
         $response = $this->getHttpClient()->get('https://api.spotify.com/v1/me', [
             'headers' => [
                 'Authorization' => 'Bearer '.$token,
-            ]
+            ],
         ]);
 
         return (array) json_decode($response->getBody(), true);


### PR DESCRIPTION
This PR adds Spotify as a provider.

Since Spotify is very popular and has many users all over the world. Natively including a provider for it will be very useful.


How to set up:

1. Create an app in [Spotify Developers](https://developer.spotify.com/dashboard/applications) and set up the callback redirect in app settings;
2. Set up the Spotify client id, client secret and redirect URI in config/services.php
```
'spotify' => [
        'client_id' => env('SPOTIFY_CLIENT_ID'),
        'client_secret' => env('SPOTIFY_CLIENT_SECRET'),
        'redirect' => env('SPOTIFY_REDIRECT'),
    ],
```