### PR TITLE
add/set approvedScopes in User

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -245,7 +245,7 @@ abstract class AbstractProvider implements ProviderContract
         return $this->user->setToken($token)
                     ->setRefreshToken(Arr::get($response, 'refresh_token'))
                     ->setExpiresIn(Arr::get($response, 'expires_in'))
-                    ->setApprovedScopes(Arr::get($response, 'scope'));
+                    ->setApprovedScopes(explode(' ', Arr::get($response, 'scope', '')));
     }
 
     /**

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -245,7 +245,7 @@ abstract class AbstractProvider implements ProviderContract
         return $this->user->setToken($token)
                     ->setRefreshToken(Arr::get($response, 'refresh_token'))
                     ->setExpiresIn(Arr::get($response, 'expires_in'))
-                    ->setApprovedScopes(explode(' ', Arr::get($response, 'scope', '')));
+                    ->setApprovedScopes(explode($this->scopeSeparator, Arr::get($response, 'scope', '')));
     }
 
     /**

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -244,7 +244,8 @@ abstract class AbstractProvider implements ProviderContract
 
         return $this->user->setToken($token)
                     ->setRefreshToken(Arr::get($response, 'refresh_token'))
-                    ->setExpiresIn(Arr::get($response, 'expires_in'));
+                    ->setExpiresIn(Arr::get($response, 'expires_in'))
+                    ->setApprovedScopes(Arr::get($response, 'scope'));
     }
 
     /**

--- a/src/Two/User.php
+++ b/src/Two/User.php
@@ -28,6 +28,12 @@ class User extends AbstractUser
     public $expiresIn;
 
     /**
+     * The scopes the users authorized.  These may be a subset of the requested scopes
+     * @var
+     */
+    public $approvedScopes;
+
+    /**
      * Set the token on the user.
      *
      * @param  string  $token
@@ -62,6 +68,17 @@ class User extends AbstractUser
     public function setExpiresIn($expiresIn)
     {
         $this->expiresIn = $expiresIn;
+
+        return $this;
+    }
+
+    /**
+     * @param  string  $approvedScopes
+     * @return $this
+     */
+    public function setApprovedScopes($approvedScopes)
+    {
+        $this->approvedScopes = $approvedScopes;
 
         return $this;
     }

--- a/src/Two/User.php
+++ b/src/Two/User.php
@@ -30,7 +30,7 @@ class User extends AbstractUser
     /**
      * The scopes the users authorized.  These may be a subset of the requested scopes.
      *
-     * @var string
+     * @var array
      */
     public $approvedScopes;
 
@@ -74,7 +74,7 @@ class User extends AbstractUser
     }
 
     /**
-     * @param  string  $approvedScopes
+     * @param  array  $approvedScopes
      * @return $this
      */
     public function setApprovedScopes($approvedScopes)

--- a/src/Two/User.php
+++ b/src/Two/User.php
@@ -29,7 +29,8 @@ class User extends AbstractUser
 
     /**
      * The scopes the users authorized.  These may be a subset of the requested scopes
-     * @var
+     *
+     * @var string
      */
     public $approvedScopes;
 

--- a/src/Two/User.php
+++ b/src/Two/User.php
@@ -28,7 +28,7 @@ class User extends AbstractUser
     public $expiresIn;
 
     /**
-     * The scopes the users authorized.  These may be a subset of the requested scopes
+     * The scopes the users authorized.  These may be a subset of the requested scopes.
      *
      * @var string
      */


### PR DESCRIPTION
It's possible for a user to grant a subset of the requested scopes.  Google has been pushing this recently...see the attached screenshot of their latest Oauth page.  Their latest default is to have no scopes checked making it quite easy for a user to select a subset of the requested scopes.

Part of the Oauth flow suggests the providers should return the approved scopes as part of the `code -> access_token` exchange if the user auth'ed a subset of the requested scopes. In my testing of Google, M365, Slack, and Zoom, the `scope` field is always returned as part of the `code -> access_token` exchange.  

There was a [recent issue ](https://github.com/laravel/socialite/issues/568) asking for this feature.

As pointed out in the link within [issue#568](https://github.com/laravel/socialite/issues/568), we should expect `code` -> `access_token`, `refresh_token (optional)`, `expires_at`, `scope (optional)`
 
There was a [recent PR ](https://github.com/laravel/socialite/pull/152/files) which brought the `User` class up from just `access_token` to also include `refresh_token`, and `expires_at`.

This PR also brings in `scope` to the `User` object.  That would complete the `User` object for storing everything the `code -> access_token` exchange returns. 

Would you like to merge this up stream?  If so, I can do whatever I can to make this acceptable up steam.  I tested this with the providers we are using.  I can also put in a PR for the SocialiteProviders manager.  In SocialiteProviders, it's much like this PR but we set the scopes [here](https://github.com/SocialiteProviders/Manager/blob/master/src/OAuth2/AbstractProvider.php#L54) and add a `parseApprovedScopes` function like the others in that file.

Tested with native Oauth Provider:
- Google Personal
- Google Workspace/Gsuite

Tested with SocialiteProviders (needs a simple PR):
- M365
- Slack (we have a fork of the Slack Provider)

![Google Oauth Screen](https://user-images.githubusercontent.com/5577089/150032518-aa22a243-dcb9-470f-8a38-98d75021f934.png)

If it's helpful, here are a few documents showing the `scope` field gets returned from a auth code to access token exchange

- [GitHub](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github)
- [Google](https://developers.google.com/identity/protocols/oauth2/web-server#exchange-authorization-code)
- [M365](https://docs.microsoft.com/en-us/graph/auth-v2-user#response)
- [Slack](https://api.slack.com/legacy/oauth#authenticating-users-with-oauth__the-oauth-flow__step-3---exchanging-a-verification-code-for-an-access-token)
- [Zoom](https://marketplace.zoom.us/docs/guides/auth/oauth#step-2-request-access-token)

<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->