### PR TITLE
[5.x] Add Twitter OAuth2 provider

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -13,6 +13,7 @@ use Laravel\Socialite\Two\GithubProvider;
 use Laravel\Socialite\Two\GitlabProvider;
 use Laravel\Socialite\Two\GoogleProvider;
 use Laravel\Socialite\Two\LinkedInProvider;
+use Laravel\Socialite\Two\TwitterProvider as TwitterOAuth2Provider;
 use League\OAuth1\Client\Server\Twitter as TwitterServer;
 
 class SocialiteManager extends Manager implements Contracts\Factory
@@ -110,6 +111,20 @@ class SocialiteManager extends Manager implements Contracts\Factory
         return $this->buildProvider(
             GitlabProvider::class, $config
         )->setHost($config['host'] ?? null);
+    }
+
+    /**
+     * Create an instance of the specified driver.
+     *
+     * @return \Laravel\Socialite\Two\AbstractProvider
+     */
+    protected function createTwitterOAuth2Driver()
+    {
+        $config = $this->config->get('services.twitter');
+
+        return $this->buildProvider(
+            TwitterOAuth2Provider::class, $config
+        );
     }
 
     /**

--- a/src/Two/TwitterProvider.php
+++ b/src/Two/TwitterProvider.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Laravel\Socialite\Two;
+
+use Illuminate\Support\Arr;
+
+class TwitterProvider extends AbstractProvider
+{
+    /**
+     * The scopes being requested.
+     *
+     * @var array
+     */
+    protected $scopes = ['users.read', 'tweet.read'];
+
+    /**
+     * Indicates if PKCE should be used.
+     *
+     * @var bool
+     */
+    protected $usesPKCE = true;
+
+    /**
+     * The separating character for the requested scopes.
+     *
+     * @var string
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://twitter.com/i/oauth2/authorize', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://api.twitter.com/2/oauth2/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get('https://api.twitter.com/2/users/me', [
+            'headers' => ['Authorization' => 'Bearer '.$token],
+            'query' => ['user.fields' => 'profile_image_url'],
+        ]);
+
+        return Arr::get(json_decode($response->getBody(), true), 'data');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id' => $user['id'],
+            'nickname' => $user['username'],
+            'name' => $user['name'],
+            'avatar' => $user['profile_image_url'],
+        ]);
+    }
+}


### PR DESCRIPTION
Unfortunately, at the moment the endpoint for receiving email (https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials) has not been added to the twitter v2 api.

https://developer.twitter.com/en/docs/twitter-api/migrate/twitter-api-endpoint-map

for: https://github.com/laravel/socialite/issues/570