### PR TITLE
Override abstract provider for Twitter's OAuth 2.0 provider

### DIFF
--- a/src/Two/TwitterProvider.php
+++ b/src/Two/TwitterProvider.php
@@ -68,4 +68,18 @@ class TwitterProvider extends AbstractProvider
             'avatar' => $user['profile_image_url'],
         ]);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAccessTokenResponse($code)
+    {
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
+            'headers' => ['Accept' => 'application/json'],
+            'auth' => [$this->clientId, $this->clientSecret],
+            'form_params' => $this->getTokenFields($code),
+        ]);
+
+        return json_decode($response->getBody(), true);
+    }
 }


### PR DESCRIPTION
For Twitter apps that are considered a [confidential client](https://developer.twitter.com/en/docs/authentication/oauth-2-0/authorization-code) i.e. web apps and automated bots, a basic `Authorization` header must be passed with the `getAccessTokenResponse` request.

Failure to do so results in [authorisation failures](https://twittercommunity.com/t/trying-to-get-oauth-2-0-token-receiving-missing-valid-authorization-header-error/163633) when attempting to fetch the authenticated user.

Fortunately, Socialite doesn't need to be aware of the app type as sending the basic header doesn't seem to cause any issues with public Twitter apps, so I've just overridden the `getAccessTokenResponse` method on the `TwitterProvider` class to send the client ID and secret as basic username and password.

Addresses #574 (Specifically, the comment [here](https://github.com/laravel/socialite/pull/574#issuecomment-1029998704)).
