### PR TITLE
Add `refreshToken` method for OAuth 2.0 providers

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -103,7 +103,7 @@ abstract class AbstractProvider implements ProviderContract
     protected $user;
 
     /**
-     * Grant type for refresh token
+     * Grant type for refresh token.
      *
      * @var string
      */
@@ -269,7 +269,7 @@ abstract class AbstractProvider implements ProviderContract
     }
 
     /**
-     * Refresh User's token
+     * Refresh User's token.
      *
      * @param  string  $token
      * @param  bool  $useScopes
@@ -356,7 +356,7 @@ abstract class AbstractProvider implements ProviderContract
             $this->refreshTokenGrantType => $token,
         ];
 
-        if ($useScopes && !empty($this->getScopes())) {
+        if ($useScopes && ! empty($this->getScopes())) {
             $fields['scope'] = $this->formatScopes($this->getScopes(), $this->scopeSeparator);
         }
 

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -56,6 +56,13 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     protected $lastToken;
 
     /**
+     * Facebook's special grant type for refresh token
+     *
+     * @var string
+     */
+    protected $refreshTokenGrantType = 'fb_exchange_token';
+
+    /**
      * {@inheritdoc}
      */
     protected function getAuthUrl($state)

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -56,7 +56,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     protected $lastToken;
 
     /**
-     * Facebook's special grant type for refresh token
+     * Facebook's special grant type for refresh token.
      *
      * @var string
      */


### PR DESCRIPTION
## Description
This PR contains a method to refresh token received from social networks  via OAuth2. This method will be helpful for projects that are storing access tokens (also refresh tokens) and they are using them on behalf of the users to receive some data, metrics etc.

Sometimes these kinds of tasks are done by cron in the night and without acknowledging users. With this feature programmers can implement the case when a users' access tokens are going to expire and they don't want to reauthorize users.

## Usage example
Users' access tokens would be stored in `user_tokens` table (model `UserToken`). The table consists of `id, user_id, network, access_token, refresh_token, expires_at, updated_at, created_at` columns.

**app/Commands/Console/RefreshTokenCommand.php**
```php
class RefreshFacebookTokens extends Command
{

    protected $signature = 'token:refresh';
    protected $description = 'Refresh tokens for all supported social networks.';

    /**
     * Execute the console command.
     */
    public function handle(): int
    {
        $userTokens = UserTokens::where('expires_at', '<=', Carbon::now())->get();

        foreach ($userTokens as $userToken) {
            $token = Socialite::driver($userToken->social_network)->refreshToken($userToken->refresh_token ?? $userToken->access_token); // (*)

            if ($token['access_token']) {
                $userToken->access_token = $token['access_token'];
            }

            $userToken->refresh_token = $token['refresh_token'] ?? null;
            $userToken->expires_at = Carbon::now()->addSeconds($token['expires_in']);
            $userToken->save();
        }

        return 0;
    }
}
```

_(*) Facebook does not return `refresh_token`. Facebook uses `access_token` in order to receive Long-Lived token._