### PR TITLE
[5.x] Use RequestOptions constants when calling the request

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Socialite\Two;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
@@ -286,8 +287,8 @@ abstract class AbstractProvider implements ProviderContract
     public function getAccessTokenResponse($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            'headers' => ['Accept' => 'application/json'],
-            'form_params' => $this->getTokenFields($code),
+            RequestOptions::HEADERS => ['Accept' => 'application/json'],
+            RequestOptions::FORM_PARAMS => $this->getTokenFields($code),
         ]);
 
         return json_decode($response->getBody(), true);

--- a/src/Two/BitbucketProvider.php
+++ b/src/Two/BitbucketProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Socialite\Two;
 
 use Exception;
+use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 
 class BitbucketProvider extends AbstractProvider implements ProviderInterface
@@ -43,7 +44,7 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get('https://api.bitbucket.org/2.0/user', [
-            'query' => ['access_token' => $token],
+            RequestOptions::QUERY => ['access_token' => $token],
         ]);
 
         $user = json_decode($response->getBody(), true);
@@ -103,9 +104,9 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            'auth' => [$this->clientId, $this->clientSecret],
-            'headers' => ['Accept' => 'application/json'],
-            'form_params' => $this->getTokenFields($code),
+            RequestOptions::AUTH => [$this->clientId, $this->clientSecret],
+            RequestOptions::HEADERS => ['Accept' => 'application/json'],
+            RequestOptions::FORM_PARAMS => $this->getTokenFields($code),
         ]);
 
         return json_decode($response->getBody(), true)['access_token'];

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Socialite\Two;
 
+use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 
 class FacebookProvider extends AbstractProvider implements ProviderInterface
@@ -77,7 +78,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     public function getAccessTokenResponse($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            'form_params' => $this->getTokenFields($code),
+            RequestOptions::FORM_PARAMS => $this->getTokenFields($code),
         ]);
 
         $data = json_decode($response->getBody(), true);
@@ -102,10 +103,10 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
         }
 
         $response = $this->getHttpClient()->get($this->graphUrl.'/'.$this->version.'/me', [
-            'headers' => [
+            RequestOptions::HEADERS => [
                 'Accept' => 'application/json',
             ],
-            'query' => $params,
+            RequestOptions::QUERY => $params,
         ]);
 
         return json_decode($response->getBody(), true);

--- a/src/Two/GithubProvider.php
+++ b/src/Two/GithubProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Socialite\Two;
 
 use Exception;
+use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 
 class GithubProvider extends AbstractProvider implements ProviderInterface
@@ -98,7 +99,7 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
     protected function getRequestOptions($token)
     {
         return [
-            'headers' => [
+            RequestOptions::HEADERS => [
                 'Accept' => 'application/vnd.github.v3+json',
                 'Authorization' => 'token '.$token,
             ],

--- a/src/Two/GitlabProvider.php
+++ b/src/Two/GitlabProvider.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Socialite\Two;
 
+use GuzzleHttp\RequestOptions;
+
 class GitlabProvider extends AbstractProvider implements ProviderInterface
 {
     /**
@@ -62,7 +64,7 @@ class GitlabProvider extends AbstractProvider implements ProviderInterface
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get($this->host.'/api/v3/user', [
-            'query' => ['access_token' => $token],
+            RequestOptions::QUERY => ['access_token' => $token],
         ]);
 
         return json_decode($response->getBody(), true);

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Socialite\Two;
 
+use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 
 class GoogleProvider extends AbstractProvider implements ProviderInterface
@@ -46,10 +47,10 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get('https://www.googleapis.com/oauth2/v3/userinfo', [
-            'query' => [
+            RequestOptions::QUERY => [
                 'prettyPrint' => 'false',
             ],
-            'headers' => [
+            RequestOptions::HEADERS => [
                 'Accept' => 'application/json',
                 'Authorization' => 'Bearer '.$token,
             ],

--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Socialite\Two;
 
+use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 
 class LinkedInProvider extends AbstractProvider implements ProviderInterface
@@ -56,11 +57,11 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
     protected function getBasicProfile($token)
     {
         $response = $this->getHttpClient()->get('https://api.linkedin.com/v2/me', [
-            'headers' => [
+            RequestOptions::HEADERS => [
                 'Authorization' => 'Bearer '.$token,
                 'X-RestLi-Protocol-Version' => '2.0.0',
             ],
-            'query' => [
+            RequestOptions::QUERY => [
                 'projection' => '(id,firstName,lastName,profilePicture(displayImage~:playableStreams))',
             ],
         ]);
@@ -77,11 +78,11 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
     protected function getEmailAddress($token)
     {
         $response = $this->getHttpClient()->get('https://api.linkedin.com/v2/emailAddress', [
-            'headers' => [
+            RequestOptions::HEADERS => [
                 'Authorization' => 'Bearer '.$token,
                 'X-RestLi-Protocol-Version' => '2.0.0',
             ],
-            'query' => [
+            RequestOptions::QUERY => [
                 'q' => 'members',
                 'projection' => '(elements*(handle~))',
             ],

--- a/src/Two/TwitterProvider.php
+++ b/src/Two/TwitterProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Socialite\Two;
 
+use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 
 class TwitterProvider extends AbstractProvider
@@ -49,8 +50,8 @@ class TwitterProvider extends AbstractProvider
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get('https://api.twitter.com/2/users/me', [
-            'headers' => ['Authorization' => 'Bearer '.$token],
-            'query' => ['user.fields' => 'profile_image_url'],
+            RequestOptions::HEADERS => ['Authorization' => 'Bearer '.$token],
+            RequestOptions::QUERY => ['user.fields' => 'profile_image_url'],
         ]);
 
         return Arr::get(json_decode($response->getBody(), true), 'data');
@@ -75,9 +76,9 @@ class TwitterProvider extends AbstractProvider
     public function getAccessTokenResponse($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            'headers' => ['Accept' => 'application/json'],
-            'auth' => [$this->clientId, $this->clientSecret],
-            'form_params' => $this->getTokenFields($code),
+            RequestOptions::HEADERS => ['Accept' => 'application/json'],
+            RequestOptions::AUTH => [$this->clientId, $this->clientSecret],
+            RequestOptions::FORM_PARAMS => $this->getTokenFields($code),
         ]);
 
         return json_decode($response->getBody(), true);

--- a/tests/LinkedInProviderTest.php
+++ b/tests/LinkedInProviderTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Socialite\Tests;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
 use Illuminate\Http\Request;
 use Laravel\Socialite\Two\LinkedInProvider;
 use Laravel\Socialite\Two\User;
@@ -37,20 +38,20 @@ class LinkedInProviderTest extends TestCase
         $guzzle = m::mock(Client::class);
         $guzzle->expects('post')->andReturns($accessTokenResponse);
         $guzzle->allows('get')->with('https://api.linkedin.com/v2/me', [
-            'headers' => [
+            RequestOptions::HEADERS => [
                 'Authorization' => 'Bearer fake-token',
                 'X-RestLi-Protocol-Version' => '2.0.0',
             ],
-            'query' => [
+            RequestOptions::QUERY => [
                 'projection' => '(id,firstName,lastName,profilePicture(displayImage~:playableStreams))',
             ],
         ])->andReturns($basicProfileResponse);
         $guzzle->allows('get')->with('https://api.linkedin.com/v2/emailAddress', [
-            'headers' => [
+            RequestOptions::HEADERS => [
                 'Authorization' => 'Bearer fake-token',
                 'X-RestLi-Protocol-Version' => '2.0.0',
             ],
-            'query' => [
+            RequestOptions::QUERY => [
                 'q' => 'members',
                 'projection' => '(elements*(handle~))',
             ],


### PR DESCRIPTION
<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR enforces the use `RequestOptions` constants when calling the request.
This allows to restrict the options to the only the one that really exist (have a dedicated constant).