### PR TITLE
5.x] Move illuminate/contracts from require-dev to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
         "php": "^7.2|^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.0|^7.0",
+        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
         "illuminate/http": "^6.0|^7.0|^8.0|^9.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
         "league/oauth1-client": "^1.10.1"
     },
     "require-dev": {
-        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",
         "phpunit/phpunit": "^8.0|^9.3"


### PR DESCRIPTION
<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Move `illuminate/contracts` from `require-dev` to `require`
cf. https://github.com/laravel/socialite/blob/5.x/src/SocialiteServiceProvider.php#L5
