### PR TITLE
Add Twitter OAuth 2 fallback call

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -138,7 +138,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function createTwitterOAuth2Driver()
     {
-        $config = $this->config->get('services.twitter');
+        $config = $this->config->get('services.twitter') ?? $this->config->get('services.twitter-oauth-2');
 
         return $this->buildProvider(
             TwitterOAuth2Provider::class, $config


### PR DESCRIPTION
This allows the Twitter OAuth 2 driver to fallback on the `twitter-oauth-2` config key as explained in the docs.

See https://github.com/laravel/socialite/issues/595