### PR TITLE
Add correct encoding and the required state param.

### DIFF
--- a/src/Two/TwitterProvider.php
+++ b/src/Two/TwitterProvider.php
@@ -29,6 +29,13 @@ class TwitterProvider extends AbstractProvider
     protected $scopeSeparator = ' ';
 
     /**
+     * The type of the encoding in the query.
+     *
+     * @var int
+     */
+    protected $encodingType = PHP_QUERY_RFC3986;
+
+    /**
      * {@inheritdoc}
      */
     public function getAuthUrl($state)
@@ -82,5 +89,19 @@ class TwitterProvider extends AbstractProvider
         ]);
 
         return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getCodeFields($state = null)
+    {
+        $fields = parent::getCodeFields($state);
+
+        if (! isset($fields['state']) {
+            $fields['state'] = 'state';
+        }
+
+        return $fields;
     }
 }


### PR DESCRIPTION
Twitter's API documentation specifies the expected encoding type, especially around space character conversions. See https://developer.twitter.com/en/docs/authentication/oauth-1-0a/percent-encoding-parameters

In addition to that, for the stateless use with PKCE, which the TwitterProvider is set to true by default, the state parameter is required nevertheless in a default `&state=state` format. See https://developer.twitter.com/en/docs/authentication/oauth-2-0/authorization-code