### PR TITLE
Add ability to override access token request headers

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -295,7 +295,7 @@ abstract class AbstractProvider implements ProviderContract
     }
 
     /**
-     * Get the headers for the token request.
+     * Get the headers for the access token request.
      *
      * @param  string  $code
      * @return array

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -287,11 +287,22 @@ abstract class AbstractProvider implements ProviderContract
     public function getAccessTokenResponse($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            RequestOptions::HEADERS => ['Accept' => 'application/json'],
+            RequestOptions::HEADERS => $this->getTokenHeaders($code),
             RequestOptions::FORM_PARAMS => $this->getTokenFields($code),
         ]);
 
         return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * Get the headers for the token request.
+     *
+     * @param  string  $code
+     * @return array
+     */
+    protected function getTokenHeaders($code)
+    {
+        return ['Accept' => 'application/json'];
     }
 
     /**


### PR DESCRIPTION
This moves the currently hardcoded `getAccessTokenResponse` into their own method.  This allows children providers to construct their own headers as needed.

A perfect example of the necessity of this feature is the newer Pinterest v5 API.  In order to exchange the code for an access token, they require an `Authorization` header composed of a base64 encoded `client_id` and `client_secret`.  Without this change, the Pinterest Provider would need to entirely reimplement the `getAccessTokenResponse` method.  **With** this change, the Pinterest Provider could simply:

```php
protected function getTokenHeaders()
{
    return array_merge(
        parent::getTokenHeaders(),
        [
            'Authorization' => 'Basic ' . base64_encode("{$this->clientId}:{$this->clientSecret}"),
        ]
    );
}
```

<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
