### PR TITLE
Set PKCE to false if using stateless method

### DIFF
--- a/src/Two/TwitterProvider.php
+++ b/src/Two/TwitterProvider.php
@@ -19,7 +19,7 @@ class TwitterProvider extends AbstractProvider
      *
      * @var bool
      */
-    protected $usesPKCE = true;
+    protected $usesPKCE = $this->isStateless();
 
     /**
      * The separating character for the requested scopes.


### PR DESCRIPTION
This will fix the unexpected reach for session while using the `stateless` method via `TwitterProvider`. Currently even if you are using `stateless`, the `$usesPKCE` causes `getCodeFields` method in `AbstractProvider.php: 194` to reach session methods.
