### PR TITLE
Fix PKCE causing session reach with stateless

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -164,12 +164,12 @@ abstract class AbstractProvider implements ProviderContract
 
         if ($this->usesState()) {
             $this->request->session()->put('state', $state = $this->getState());
+            
+            if ($this->usesPKCE()) {
+                $this->request->session()->put('code_verifier', $this->getCodeVerifier());
+            }
         }
-
-        if ($this->usesPKCE()) {
-            $this->request->session()->put('code_verifier', $this->getCodeVerifier());
-        }
-
+        
         return new RedirectResponse($this->getAuthUrl($state));
     }
 
@@ -202,13 +202,13 @@ abstract class AbstractProvider implements ProviderContract
 
         if ($this->usesState()) {
             $fields['state'] = $state;
+            
+            if ($this->usesPKCE()) {
+                $fields['code_challenge'] = $this->getCodeChallenge();
+                $fields['code_challenge_method'] = $this->getCodeChallengeMethod();
+            }
         }
-
-        if ($this->usesPKCE()) {
-            $fields['code_challenge'] = $this->getCodeChallenge();
-            $fields['code_challenge_method'] = $this->getCodeChallengeMethod();
-        }
-
+        
         return array_merge($fields, $this->parameters);
     }
 
@@ -321,7 +321,7 @@ abstract class AbstractProvider implements ProviderContract
             'redirect_uri' => $this->redirectUrl,
         ];
 
-        if ($this->usesPKCE()) {
+        if ($this->usesState() && $this->usesPKCE()) {
             $fields['code_verifier'] = $this->request->session()->pull('code_verifier');
         }
 


### PR DESCRIPTION
Code improvement for PKCE usage while using `stateless` method in `TwitterProvider`. Currently the `stateless` method does not prevent the default enabled property `$usesPKCE` in `TwitterProvider.php` and checking if the driver uses state first resolves unnecessary PKCE usage (which also uses sessions).
