### PR TITLE
[5.x] Add app property

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -19,6 +19,15 @@ use League\OAuth1\Client\Server\Twitter as TwitterServer;
 class SocialiteManager extends Manager implements Contracts\Factory
 {
     /**
+     * The application instance.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     *
+     * @deprecated Will be removed in a future Socialite release.
+     */
+    protected $app;
+
+    /**
      * Get a driver instance.
      *
      * @param  string  $driver


### PR DESCRIPTION
This PR adds the app property to the base socialite manager class to prevent PHP 8.2 warnings.

Fixes https://github.com/laravel/socialite/issues/619