### PR TITLE
[5.x] Fix misspelling uppercase "GitHub"

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -9,7 +9,7 @@ use InvalidArgumentException;
 use Laravel\Socialite\One\TwitterProvider;
 use Laravel\Socialite\Two\BitbucketProvider;
 use Laravel\Socialite\Two\FacebookProvider;
-use Laravel\Socialite\Two\GithubProvider;
+use Laravel\Socialite\Two\GitHubProvider;
 use Laravel\Socialite\Two\GitlabProvider;
 use Laravel\Socialite\Two\GoogleProvider;
 use Laravel\Socialite\Two\LinkedInProvider;
@@ -43,12 +43,12 @@ class SocialiteManager extends Manager implements Contracts\Factory
      *
      * @return \Laravel\Socialite\Two\AbstractProvider
      */
-    protected function createGithubDriver()
+    protected function createGitHubDriver()
     {
         $config = $this->config->get('services.github');
 
         return $this->buildProvider(
-            GithubProvider::class, $config
+            GitHubProvider::class, $config
         );
     }
 

--- a/src/Two/GitHubProvider.php
+++ b/src/Two/GitHubProvider.php
@@ -6,7 +6,7 @@ use Exception;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 
-class GithubProvider extends AbstractProvider implements ProviderInterface
+class GitHubProvider extends AbstractProvider implements ProviderInterface
 {
     /**
      * The scopes being requested.


### PR DESCRIPTION
Fix misspelling uppercase "GitHub"
