### PR TITLE
[5.x] Add support for new google authentication library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "illuminate/http": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "league/oauth1-client": "^1.10.1"
+        "league/oauth1-client": "^1.10.1",
+        "ext-openssl": "*"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/src/Jwt/GoogleProvider.php
+++ b/src/Jwt/GoogleProvider.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Socialite\Jwt;
 
-use _PHPStan_a3459023a\Nette\Neon\Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Laravel\Socialite\Contracts\Provider;

--- a/src/Jwt/GoogleProvider.php
+++ b/src/Jwt/GoogleProvider.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Laravel\Socialite\Jwt;
+
+use _PHPStan_a3459023a\Nette\Neon\Exception;
+use Illuminate\Support\Arr;
+use Illuminate\Http\Request;
+use Laravel\Socialite\Contracts\Provider;
+
+class GoogleProvider implements Provider
+{
+    protected $user;
+    protected $request;
+    protected $clientId;
+    protected $payload;
+
+    public function __construct(Request $request, $clientId)
+    {
+        $this->request = $request;
+        $this->clientId = $clientId;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function redirect()
+    {
+       throw new Exception('Redirect is deprecated for the new Google Auth, see https://developers.google.com/identity/gsi/web/guides/migration#html_and_javascript');
+    }
+
+
+    /**
+     * Get the User instance for the authenticated user.
+     *
+     * @throws InvalidJwtException
+     * @return \Laravel\Socialite\Contracts\User
+     */
+    public function user()
+    {
+        if ($this->user) {
+            return $this->user;
+        }
+        $jwt = $this->request->credential;
+        if($jwt === null){
+            throw new InvalidJwtException("Empty JWT payload");
+        }
+        if(!$this->verifyJwtSignature($jwt)){
+            throw new InvalidJwtException('Invalid JWT signature');
+        }
+        if (!in_array(Arr::get($this->payload, 'iss'), ['accounts.google.com', 'https://accounts.google.com'])) {
+            throw new InvalidJwtException('Invalid JWT issuer');
+        }
+        if (Arr::get($this->payload, 'aud') !== $this->clientId) {
+            throw new InvalidJwtException('Client ID mismatch');
+        }
+        if (Arr::get($this->payload, 'exp') < time()) {
+            throw new InvalidJwtException('Expired token');
+        }
+        if (Arr::get($this->payload, 'iat') > time()) {
+            throw new InvalidJwtException('Token used before issued');
+        }
+
+        return $this->user = $this->mapUserToObject($this->payload)
+            ->setOrganization(Arr::get($this->payload, 'hd'));
+    }
+
+
+    /**
+     * Map the raw user array to a Socialite User instance.
+     *
+     * @param  array  $user
+     * @return \Laravel\Socialite\Jwt\User
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id' => Arr::get($user, 'sub'),
+            'nickname' => Arr::get($user, 'nickname'),
+            'name' => Arr::get($user, 'name'),
+            'email_verified' => Arr::get($user, 'email_verified'),
+            'email' => Arr::get($user, 'email'),
+            'avatar' => $avatarUrl = Arr::get($user, 'picture'),
+            'avatar_original' => $avatarUrl,
+        ]);
+    }
+
+    /**
+     * Verifies the signature of the JWT issued, via Google Certs
+     *
+     * @param  string  $jwt
+     * @return boolean
+     */
+    protected function verifyJwtSignature($jwt){
+        $jwt_parts = explode('.', $jwt);
+
+        $header = json_decode($this->base64UrlDecode($jwt_parts[0]), true);
+        $this->payload = json_decode($this->base64UrlDecode($jwt_parts[1]), true);
+        $signature = $this->base64UrlDecode($jwt_parts[2]);
+
+        $key_id = Arr::get($header, 'kid');
+        $certificates = json_decode(file_get_contents('https://www.googleapis.com/oauth2/v1/certs'), true);
+        $publicKey = openssl_pkey_get_public($certificates[$key_id]);
+
+        return openssl_verify($jwt_parts[0] . '.' . $jwt_parts[1], $signature, $publicKey , OPENSSL_ALGO_SHA256);
+    }
+
+    /**
+     * Decodes a Base64 URL-encoded string.
+     *
+     * This function converts a Base64 URL-encoded string to its original form by
+     * replacing the URL-safe characters '-' and '_' with their respective Base64
+     * characters '+' and '/', and then decoding the string using the standard
+     * Base64 algorithm.
+     *
+     * @param string $data The Base64 URL-encoded string to decode.
+     * @return string The decoded string.
+     */
+    protected function base64UrlDecode($data)
+    {
+        return base64_decode(strtr($data, '-_', '+/'));
+    }
+}

--- a/src/Jwt/GoogleProvider.php
+++ b/src/Jwt/GoogleProvider.php
@@ -24,7 +24,7 @@ class GoogleProvider implements Provider
      */
     public function redirect()
     {
-       throw new Exception('Redirect is deprecated for the new Google Auth, see https://developers.google.com/identity/gsi/web/guides/migration#html_and_javascript');
+       throw new \Exception('Redirect is deprecated for the new Google Auth, see https://developers.google.com/identity/gsi/web/guides/migration#html_and_javascript');
     }
 
 

--- a/src/Jwt/GoogleProvider.php
+++ b/src/Jwt/GoogleProvider.php
@@ -129,10 +129,33 @@ class GoogleProvider implements Provider
         $signature = $this->base64UrlDecode($jwtParts[2]);
 
         $keyId = Arr::get($header, 'kid');
-        $certificates = json_decode(file_get_contents('https://www.googleapis.com/oauth2/v1/certs'), true);
+        $certificates = $this->fetchCertificates();
         $publicKey = openssl_pkey_get_public($certificates[$keyId]);
 
-        return openssl_verify($jwtParts[0] . '.' . $jwtParts[1], $signature, $publicKey , OPENSSL_ALGO_SHA256);
+        return $this->verifySignature($jwtParts[0] . '.' . $jwtParts[1], $signature, $publicKey);
+    }
+
+    /**
+     * Verify the provided signature using OpenSSL.
+     *
+     * @param  string  $data
+     * @param  string  $signature
+     * @param  resource|bool  $publicKey
+     * @return bool
+     */
+    protected function verifySignature($data, $signature, $publicKey): bool
+    {
+        return openssl_verify($data, $signature, $publicKey , OPENSSL_ALGO_SHA256);
+    }
+
+    /**
+     * Fetches the Google signing certificates for JWTs.
+     *
+     * @return array
+     */
+    protected function fetchCertificates(): array
+    {
+        return json_decode(file_get_contents('https://www.googleapis.com/oauth2/v1/certs'), true);
     }
 
     /**

--- a/src/Jwt/InvalidJwtException.php
+++ b/src/Jwt/InvalidJwtException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Socialite\Jwt;
+
+use InvalidArgumentException;
+
+class InvalidJwtException extends InvalidArgumentException
+{
+
+}

--- a/src/Jwt/User.php
+++ b/src/Jwt/User.php
@@ -6,18 +6,32 @@ use Laravel\Socialite\AbstractUser;
 
 class User extends AbstractUser
 {
-   public $email_verified;
-
-   public $organization;
-
-
-   public function isEmailVerified()
-   {
-      return $this->email_verified;
-   }
+    /**
+     * The email verification status.
+     *
+     * @var bool
+     */
+    public $email_verified;
 
     /**
-     * Set the organization for current user
+     * The organization the user belongs to.
+     *
+     * @var string
+     */
+    public $organization;
+
+    /**
+     * Checks if the user's email is verified.
+     *
+     * @return bool
+     */
+    public function isEmailVerified()
+    {
+        return $this->email_verified;
+    }
+
+    /**
+     * Sets the organization for the current user.
      *
      * @param  string $organization
      * @return $this
@@ -28,5 +42,4 @@ class User extends AbstractUser
 
         return $this;
     }
-
 }

--- a/src/Jwt/User.php
+++ b/src/Jwt/User.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Laravel\Socialite\Jwt;
+
+use Laravel\Socialite\AbstractUser;
+
+class User extends AbstractUser
+{
+   public $email_verified;
+
+   public $organization;
+
+
+   public function isEmailVerified()
+   {
+      return $this->email_verified;
+   }
+
+    /**
+     * Set the organization for current user
+     *
+     * @param  string $organization
+     * @return $this
+     */
+    public function setOrganization($organization)
+    {
+        $this->organization = $organization;
+
+        return $this;
+    }
+
+}

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Manager;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Laravel\Socialite\Jwt\GoogleProvider as GoogleJwtProvider;
 use Laravel\Socialite\One\TwitterProvider;
 use Laravel\Socialite\Two\BitbucketProvider;
 use Laravel\Socialite\Two\FacebookProvider;
@@ -77,6 +78,20 @@ class SocialiteManager extends Manager implements Contracts\Factory
 
         return $this->buildProvider(
             GoogleProvider::class, $config
+        );
+    }
+
+    /**
+     * Create an instance of the specified driver.
+     *
+     * @return GoogleJwtProvider
+     */
+    protected function createGoogleJwtDriver()
+    {
+        $config = $this->config->get('services.google');
+
+        return $this->buildProvider(
+            GoogleJwtProvider::class, $config
         );
     }
 

--- a/tests/GoogleProviderTest.php
+++ b/tests/GoogleProviderTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Laravel\Socialite\Tests;
+
+use Illuminate\Http\Request;
+use Laravel\Socialite\Jwt\GoogleProvider;
+use Laravel\Socialite\Jwt\InvalidJwtException;
+use Laravel\Socialite\Jwt\User;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class GoogleProviderTest extends TestCase
+{
+    public function testRedirectThrowsException()
+    {
+        $request = new Request();
+        $provider = new GoogleProvider($request, 'dummy-client-id');
+
+        $this->expectException(\RuntimeException::class);
+
+        $provider->redirect();
+    }
+
+    public function testUserWithNullCredentialThrowsException()
+    {
+        $request = new Request();
+        $request->replace(['credential' => null]);
+
+        $provider = new GoogleProvider($request, 'dummy-client-id');
+
+        $this->expectException(InvalidJwtException::class);
+        $this->expectExceptionMessage('Empty JWT payload');
+
+        $provider->user();
+    }
+
+    public function testVerifyJwtSignatureWithInvalidJwt()
+    {
+        $jwt = $this->generateDummyJwt();
+
+        $request = new Request();
+        $request->replace(['credential' => $jwt]);
+
+        $provider = m::mock(GoogleProvider::class, [$request, 'dummy-client-id'])
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+
+        $provider->shouldReceive('fetchCertificates')
+            ->once()
+            ->andReturn(['dummyKeyId' => 'dummyPublicKey']);
+
+        $provider->shouldReceive('verifySignature')
+            ->once()
+            ->andReturn(false);
+
+        $this->expectException(InvalidJwtException::class);
+        $this->expectExceptionMessage('Invalid JWT signature');
+
+        $provider->user();
+    }
+
+    public function testUserWithValidJwtReturnsUserInstance()
+    {
+        $jwt = $this->generateDummyJwt();
+
+        $request = new Request();
+        $request->replace(['credential' => $jwt]);
+
+        $provider = m::mock(GoogleProvider::class, [$request, 'dummy-client-id'])
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+
+        $provider->shouldReceive('fetchCertificates')
+            ->once()
+            ->andReturn(['dummyKeyId' => 'dummyPublicKey']);
+
+        $provider->shouldReceive('verifySignature')
+            ->once()
+            ->andReturn(true);
+
+        $user = $provider->user();
+
+        $this->assertInstanceOf(User::class, $user);
+    }
+
+    private function generateDummyJwt(): string
+    {
+        $header = ['alg' => 'RS256', 'kid' => 'dummyKeyId'];
+        $payload = ['sub' => '1234567890', 'name' => 'John Doe', 'iss' => 'accounts.google.com', 'aud' => 'dummy-client-id', 'exp' => time() + 3600, 'iat' => time(), 'email_verified' => true, 'email' => 'john@doe.com'];
+        $signature = 'dummySignature';
+
+        $jwtParts = [
+            base64_encode(json_encode($header)),
+            base64_encode(json_encode($payload)),
+            base64_encode($signature)
+        ];
+
+        return implode('.', $jwtParts);
+    }
+}


### PR DESCRIPTION
Created a new provider which uses the new Google Authentication Library (https://developers.google.com/identity/gsi/web/guides/overview?hl=en) 

This is related to #634.

To use the new library you would have to use `Socialite::driver('google-jwt')->user()`

the redirect method is deprecated, as google allows only for HTML and JS integrations, and now throws a message. 

For client side one could use:

 ```
<script src="https://accounts.google.com/gsi/client" async defer></script>

                    <div id="g_id_onload"
                         data-client_id="{{config('services.google.client_id')}}"
                         data-login_uri="{{config('services.google.redirect')}}"
                         data-auto_prompt="false">
                    </div>
                    <div class="g_id_signin"
                         data-type="standard"
                         data-size="large"
                         data-theme="outline"
                         data-text="sign_in_with"
                         data-shape="rectangular"
                         data-logo_alignment="left">
                    </div>
```

Basically, Google moved away from OAuth and now issue JWT's in order to authenticate the user.

My PR checks for the JWT, validates it and returns an User instance based on data provided.
I've also added a dependency for the openssl PHP extension, which is used to verify the signature of the JWT's with Google certs.

Both authentication methods are available via: 'google' and 'google-jwt' drivers.

I didn't add testing yet because I didn't know which package to use for mocking the JWT payloads.
