### PR TITLE
Fix: Unable to use updated config object when using Laravel Octane

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -222,6 +222,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
     {
         $this->app = $container;
         $this->container = $container;
+        $this->config = $container->make('config');
 
         return $this;
     }


### PR DESCRIPTION
Fixing the issue described here: https://github.com/laravel/socialite/issues/638

Short summary:

Octane reset SocialiteManager on each request and assign new $container object to it. However, SocialiteManager is already booted and has $this->config property, which was loaded at the very beginning from previous requests and this object stays the same and contain outdated data.
