### PR TITLE
[5.x] Add support for Slack driver

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -13,6 +13,7 @@ use Laravel\Socialite\Two\GithubProvider;
 use Laravel\Socialite\Two\GitlabProvider;
 use Laravel\Socialite\Two\GoogleProvider;
 use Laravel\Socialite\Two\LinkedInProvider;
+use Laravel\Socialite\Two\SlackProvider;
 use Laravel\Socialite\Two\TwitterProvider as TwitterOAuth2Provider;
 use League\OAuth1\Client\Server\Twitter as TwitterServer;
 
@@ -151,6 +152,20 @@ class SocialiteManager extends Manager implements Contracts\Factory
 
         return $this->buildProvider(
             TwitterOAuth2Provider::class, $config
+        );
+    }
+
+    /**
+     * Create an instance of the specified driver.
+     *
+     * @return \Laravel\Socialite\Two\AbstractProvider
+     */
+    protected function createSlackDriver()
+    {
+        $config = $this->config->get('services.slack');
+
+        return $this->buildProvider(
+            SlackProvider::class, $config
         );
     }
 

--- a/src/Two/SlackProvider.php
+++ b/src/Two/SlackProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Laravel\Socialite\Two;
+
+use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Arr;
+
+class SlackProvider extends AbstractProvider
+{
+    /**
+     * The scopes being requested.
+     *
+     * @var array
+     */
+    protected $scopes = ['identity.basic', 'identity.email', 'identity.team', 'identity.avatar'];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://slack.com/oauth/authorize', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://slack.com/api/oauth.access';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get('https://slack.com/api/users.identity', [
+            RequestOptions::HEADERS => ['Authorization' => 'Bearer '.$token],
+        ]);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->setRaw($user)->map([
+            'id' => Arr::get($user, 'user.id'),
+            'name' => Arr::get($user, 'user.name'),
+            'email' => Arr::get($user, 'user.email'),
+            'avatar' => Arr::get($user, 'user.image_512'),
+            'organization_id' => Arr::get($user, 'team.id'),
+        ]);
+    }
+}


### PR DESCRIPTION
This PR introduces support for a new Slack OAuth 2.0 driver. To use it, you'll need to create a new [Slack app](https://api.slack.com/apps?new_app=1).