### PR TITLE
Update Slack provider to use v2 API and allow Bot tokens

### DIFF
--- a/src/Two/SlackProvider.php
+++ b/src/Two/SlackProvider.php
@@ -22,6 +22,18 @@ class SlackProvider extends AbstractProvider
     protected $scopeKey = 'user_scope';
 
     /**
+     * Indicate that the requested token should be for a bot user.
+     *
+     * @return $this
+     */
+    public function asBotUser()
+    {
+        $this->scopeKey = 'scope';
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getAuthUrl($state)
@@ -61,18 +73,6 @@ class SlackProvider extends AbstractProvider
             'avatar' => Arr::get($user, 'user.image_512'),
             'organization_id' => Arr::get($user, 'team.id'),
         ]);
-    }
-
-    /**
-     * Set the key used for scopes in the request.
-     *
-     * @return $this
-     */
-    public function asBotUser()
-    {
-        $this->scopeKey = 'scope';
-
-        return $this;
     }
 
     /**

--- a/src/Two/SlackProvider.php
+++ b/src/Two/SlackProvider.php
@@ -15,11 +15,18 @@ class SlackProvider extends AbstractProvider
     protected $scopes = ['identity.basic', 'identity.email', 'identity.team', 'identity.avatar'];
 
     /**
+     * The key used for scopes.
+     *
+     * @var string
+     */
+    protected $scopeKey = 'user_scope';
+
+    /**
      * {@inheritdoc}
      */
     public function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase('https://slack.com/oauth/authorize', $state);
+        return $this->buildAuthUrlFromBase('https://slack.com/oauth/v2/authorize', $state);
     }
 
     /**
@@ -27,7 +34,7 @@ class SlackProvider extends AbstractProvider
      */
     protected function getTokenUrl()
     {
-        return 'https://slack.com/api/oauth.access';
+        return 'https://slack.com/api/oauth.v2.access';
     }
 
     /**
@@ -54,5 +61,51 @@ class SlackProvider extends AbstractProvider
             'avatar' => Arr::get($user, 'user.image_512'),
             'organization_id' => Arr::get($user, 'team.id'),
         ]);
+    }
+
+    /**
+     * Set the key used for scopes in the request.
+     *
+     * @return $this
+     */
+    public function asBotUser()
+    {
+        $this->scopeKey = 'scope';
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getCodeFields($state = null)
+    {
+        $fields = parent::getCodeFields($state);
+
+        if ($this->scopeKey === 'user_scope') {
+            $fields['scope'] = '';
+            $fields['user_scope'] = $this->formatScopes($this->scopes, $this->scopeSeparator);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAccessTokenResponse($code)
+    {
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
+            RequestOptions::HEADERS => $this->getTokenHeaders($code),
+            RequestOptions::FORM_PARAMS => $this->getTokenFields($code),
+        ]);
+
+        $result = json_decode($response->getBody(), true);
+
+        if ($this->scopeKey === 'user_scope') {
+            return $result['authed_user'];
+        }
+
+        return $result;
     }
 }


### PR DESCRIPTION
This PR changes a few things with Slack:

1. Switches to the v2 API.
2. Adds a `asBotUser()` method that switches the type of scopes requested. Slack has two kinds of tokens; `xoxb` (bot) and `xoxp` (user). When using `asBotUser()` the `user()` method will return an empty user, but a bot token will still be available.