### PR TITLE
[5.x] Add getToken() method to User contract

### DIFF
--- a/src/AbstractUser.php
+++ b/src/AbstractUser.php
@@ -43,6 +43,13 @@ abstract class AbstractUser implements ArrayAccess, User
     public $avatar;
 
     /**
+     * The user's access token.
+     *
+     * @var string
+     */
+    public $token;
+
+    /**
      * The user's raw attributes.
      *
      * @var array
@@ -127,6 +134,16 @@ abstract class AbstractUser implements ArrayAccess, User
         $this->user = $user;
 
         return $this;
+    }
+
+    /**
+     * Get the token of the user.
+     *
+     * @return string|null
+     */
+    public function getToken()
+    {
+        return $this->token;
     }
 
     /**

--- a/src/Contracts/User.php
+++ b/src/Contracts/User.php
@@ -38,4 +38,11 @@ interface User
      * @return string|null
      */
     public function getAvatar();
+
+    /**
+     * Get the token of the user.
+     *
+     * @return string|null
+     */
+    public function getToken();
 }

--- a/src/One/User.php
+++ b/src/One/User.php
@@ -7,13 +7,6 @@ use Laravel\Socialite\AbstractUser;
 class User extends AbstractUser
 {
     /**
-     * The user's access token.
-     *
-     * @var string
-     */
-    public $token;
-
-    /**
      * The user's access token secret.
      *
      * @var string

--- a/src/Two/User.php
+++ b/src/Two/User.php
@@ -7,13 +7,6 @@ use Laravel\Socialite\AbstractUser;
 class User extends AbstractUser
 {
     /**
-     * The user's access token.
-     *
-     * @var string
-     */
-    public $token;
-
-    /**
      * The refresh token that can be exchanged for a new access token.
      *
      * @var string


### PR DESCRIPTION
This PR adds a new `getToken()` method to the abstract `User` class that returns the `$token` property value that both `\Laravel\Socialite\One\User` and `\Laravel\Socialite\Two\User` share. I also moved the declaration of the property to the abstract class because it's the same in both subclasses.

This doesn't break backwards compatibility so it should be pretty harmless to integrate in a minor version.
