### PR TITLE
Fix phpstan issues in Twitter and Slack drivers

### DIFF
--- a/src/Two/SlackProvider.php
+++ b/src/Two/SlackProvider.php
@@ -5,7 +5,7 @@ namespace Laravel\Socialite\Two;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 
-class SlackProvider extends AbstractProvider
+class SlackProvider extends AbstractProvider implements ProviderInterface
 {
     /**
      * The scopes being requested.

--- a/src/Two/TwitterProvider.php
+++ b/src/Two/TwitterProvider.php
@@ -5,7 +5,7 @@ namespace Laravel\Socialite\Two;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 
-class TwitterProvider extends AbstractProvider
+class TwitterProvider extends AbstractProvider implements ProviderInterface
 {
     /**
      * The scopes being requested.


### PR DESCRIPTION
This fixes an issue where phpstan throws: `Access to an undefined property Laravel\Socialite\Contracts\User::$token` on code like this:
```
$oauth_user = Socialite::driver($provider)->user();
$token = $oauth_user->token;
```

After the fix all OAuth2 drivers use the same `implements ProviderInterface` clause.

