### PR TITLE
[5.x] Include GitHub `node_id` field

### DIFF
--- a/src/Two/GithubProvider.php
+++ b/src/Two/GithubProvider.php
@@ -83,6 +83,7 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
     {
         return (new User)->setRaw($user)->map([
             'id' => $user['id'],
+            'nodeId' => $user['node_id'],
             'nickname' => $user['login'],
             'name' => Arr::get($user, 'name'),
             'email' => Arr::get($user, 'email'),


### PR DESCRIPTION

It has become and more common to directly identity the GitHub user via their `node_id`.
For different reasons, that would be too long to explain:

https://docs.github.com/en/graphql/guides/using-global-node-ids

I believe it would make the user object to be populated with it.