### PR TITLE
Update LinkedInProvider.php for new LI OpenId

### DIFF
--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -12,7 +12,7 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
      *
      * @var array
      */
-    protected $scopes = ['r_liteprofile', 'r_emailaddress'];
+    protected $scopes = ['openid', 'profile', 'email'];
 
     /**
      * The separating character for the requested scopes.
@@ -43,8 +43,9 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
     protected function getUserByToken($token)
     {
         $basicProfile = $this->getBasicProfile($token);
-        $emailAddress = $this->getEmailAddress($token);
+        // $emailAddress = $this->getEmailAddress($token);
 
+        return $basicProfile;
         return array_merge($basicProfile, $emailAddress);
     }
 
@@ -56,39 +57,13 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getBasicProfile($token)
     {
-        $response = $this->getHttpClient()->get('https://api.linkedin.com/v2/me', [
+        $response = $this->getHttpClient()->get('https://api.linkedin.com/v2/userinfo', [
             RequestOptions::HEADERS => [
-                'Authorization' => 'Bearer '.$token,
+                'Authorization' => 'Bearer ' . $token,
                 'X-RestLi-Protocol-Version' => '2.0.0',
-            ],
-            RequestOptions::QUERY => [
-                'projection' => '(id,firstName,lastName,profilePicture(displayImage~:playableStreams))',
-            ],
+            ]
         ]);
-
         return (array) json_decode($response->getBody(), true);
-    }
-
-    /**
-     * Get the email address for the user.
-     *
-     * @param  string  $token
-     * @return array
-     */
-    protected function getEmailAddress($token)
-    {
-        $response = $this->getHttpClient()->get('https://api.linkedin.com/v2/emailAddress', [
-            RequestOptions::HEADERS => [
-                'Authorization' => 'Bearer '.$token,
-                'X-RestLi-Protocol-Version' => '2.0.0',
-            ],
-            RequestOptions::QUERY => [
-                'q' => 'members',
-                'projection' => '(elements*(handle~))',
-            ],
-        ]);
-
-        return (array) Arr::get((array) json_decode($response->getBody(), true), 'elements.0.handle~');
     }
 
     /**
@@ -96,27 +71,22 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user)
     {
-        $preferredLocale = Arr::get($user, 'firstName.preferredLocale.language').'_'.Arr::get($user, 'firstName.preferredLocale.country');
-        $firstName = Arr::get($user, 'firstName.localized.'.$preferredLocale);
-        $lastName = Arr::get($user, 'lastName.localized.'.$preferredLocale);
 
-        $images = (array) Arr::get($user, 'profilePicture.displayImage~.elements', []);
-        $avatar = Arr::first($images, function ($image) {
-            return $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] === 100;
-        });
-        $originalAvatar = Arr::first($images, function ($image) {
-            return $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] === 800;
-        });
+        $preferredLocale = Arr::get($user, 'locale.language', []);
+        $firstName = Arr::get($user, 'given_name', '');
+        $lastName = Arr::get($user, 'family_name', '');
+        $avatar = Arr::get($user, 'picture', []);
+        $originalAvatar = $avatar;
 
         return (new User)->setRaw($user)->map([
-            'id' => $user['id'],
+            'id' => $user['sub'],
             'nickname' => null,
-            'name' => $firstName.' '.$lastName,
+            'name' => $firstName . ' ' . $lastName,
             'first_name' => $firstName,
             'last_name' => $lastName,
-            'email' => Arr::get($user, 'emailAddress'),
-            'avatar' => Arr::get($avatar, 'identifiers.0.identifier'),
-            'avatar_original' => Arr::get($originalAvatar, 'identifiers.0.identifier'),
+            'email' => Arr::get($user, 'email'),
+            'avatar' => $avatar,
+            'avatar_original' => $originalAvatar,
         ]);
     }
 }


### PR DESCRIPTION
See details on 

Sign in with LinkedIn is deprecated, here you have the new OpenId method #1054
https://github.com/SocialiteProviders/Providers/issues/1054

Linkedin changed its authentication method from Sign in with LinkedIn to Sign in with LinkedIn using OpenID Connect, since then the new app registered recently had this error.



<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
