### PR TITLE
(feat) Extract some logic to a `userInstance` method.

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -245,13 +245,13 @@ abstract class AbstractProvider implements ProviderContract
     }
 
     /**
-     * Get the user instance.
+     * Create a user instance from the given data.
      *
      * @param  array  $response
      * @param  array  $user
      * @return \Laravel\Socialite\Two\User
      */
-    public function userInstance(array $response, array $user)
+    protected function userInstance(array $response, array $user)
     {
         $this->user = $this->mapUserToObject($user);
 

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -239,14 +239,26 @@ abstract class AbstractProvider implements ProviderContract
 
         $response = $this->getAccessTokenResponse($this->getCode());
 
-        $this->user = $this->mapUserToObject($this->getUserByToken(
-            $token = Arr::get($response, 'access_token')
-        ));
+        $user = $this->getUserByToken(Arr::get($response, 'access_token'));
 
-        return $this->user->setToken($token)
-                    ->setRefreshToken(Arr::get($response, 'refresh_token'))
-                    ->setExpiresIn(Arr::get($response, 'expires_in'))
-                    ->setApprovedScopes(explode($this->scopeSeparator, Arr::get($response, 'scope', '')));
+        return $this->userInstance($response, $user);
+    }
+
+    /**
+     * Get the user instance.
+     *
+     * @param  array  $response
+     * @param  array  $user
+     * @return \Laravel\Socialite\Two\User
+     */
+    public function userInstance(array $response, array $user)
+    {
+        $this->user = $this->mapUserToObject($user);
+
+        return $this->user->setToken(Arr::get($response, 'access_token'))
+            ->setRefreshToken(Arr::get($response, 'refresh_token'))
+            ->setExpiresIn(Arr::get($response, 'expires_in'))
+            ->setApprovedScopes(explode($this->scopeSeparator, Arr::get($response, 'scope', '')));
     }
 
     /**


### PR DESCRIPTION
This PR extracts some of the logic of the `\Laravel\Socialite\Two\AbstractProvider::user()` method into a new `\Laravel\Socialite\Two\AbstractProvider::userInstance()` method.

Nothing changes, but each provider can now override `userInstance()` and had some extra logic or retrieve additional data.

Probably one of the first use case could be for the `GitHub` provider and its new expiring tokens: the token response now comes with a new field called `refresh_token_expires_in` (possibly `null`), that will can now be attached to the user in a simple way:

```php
// in src/Two/GithubProvider.php
/**
 * {@inheritdoc}
 */
function userInstance(array $response, array $user)
{
    $this->user = parent::userInstance($response, $user);
    $this->user->refreshTokenExpiresIn = $response['refresh_token_expires_in'] ?? null;

    return $this->user;
}
```

---

**Note:**
I am not opinionated concerning the name of this method, that could be renamed. 