### PR TITLE
Updating the api for getting emails as previous one not working for github provider

### DIFF
--- a/src/Two/GithubProvider.php
+++ b/src/Two/GithubProvider.php
@@ -59,7 +59,7 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getEmailByToken($token)
     {
-        $emailsUrl = 'https://api.github.com/user/emails';
+        $emailsUrl = 'https://api.github.com/user/public_emails';
 
         try {
             $response = $this->getHttpClient()->get(


### PR DESCRIPTION
When we are getting emails list with previous api for github.  When we are getting by user
`use Laravel\Socialite\Facades\Socialite; `
`$user = Socialite::driver('github')->userFromToken($token);`
So, I checked the api call manually with valid token still not getting the email. Then in github docs find another api endpoint to get the public emails. So just changing the urls `https://../user/emails to https://../user/public_emails` it fixed the problem.



