### PR TITLE
update avatar and originalAvatar display size check

### DIFF
--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -105,13 +105,13 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
             return (
                     $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] ??
                     $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['displaySize']['width']
-                ) === 100;
+            ) === 100;
         });
         $originalAvatar = Arr::first($images, function ($image) {
             return (
                     $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] ??
                     $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['displaySize']['width']
-                ) === 800;
+            ) === 800;
         });
 
         return (new User)->setRaw($user)->map([

--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -102,10 +102,16 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
 
         $images = (array) Arr::get($user, 'profilePicture.displayImage~.elements', []);
         $avatar = Arr::first($images, function ($image) {
-            return $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] === 100;
+            return (
+                    $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] ??
+                    $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['displaySize']['width']
+                ) === 100;
         });
         $originalAvatar = Arr::first($images, function ($image) {
-            return $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] === 800;
+            return (
+                    $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] ??
+                    $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['displaySize']['width']
+                ) === 800;
         });
 
         return (new User)->setRaw($user)->map([

--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -103,14 +103,14 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
         $images = (array) Arr::get($user, 'profilePicture.displayImage~.elements', []);
         $avatar = Arr::first($images, function ($image) {
             return (
-                    $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] ??
-                    $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['displaySize']['width']
+                $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] ??
+                $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['displaySize']['width']
             ) === 100;
         });
         $originalAvatar = Arr::first($images, function ($image) {
             return (
-                    $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] ??
-                    $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['displaySize']['width']
+                $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] ??
+                $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['displaySize']['width']
             ) === 800;
         });
 


### PR DESCRIPTION
The linkedIn response replaced/removed the array key `storageSize` with `displaySize`, this change will check for both.

It currently throws an exception:

```
ErrorException GET /auth/linkedin
Undefined array key "storageSize"
```

Closes: https://github.com/laravel/socialite/issues/669

<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
