### PR TITLE
[5.x] Add refreshToken method

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -341,6 +341,33 @@ abstract class AbstractProvider implements ProviderContract
     }
 
     /**
+     * Refresh a user access token with a refresh token.
+     *
+     * @param  string  $refreshToken
+     * @return Token
+     */
+    public function refreshToken($refreshToken)
+    {
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
+            RequestOptions::HEADERS => ['Accept' => 'application/json'],
+            RequestOptions::FORM_PARAMS => [
+                'grant_type' => 'refresh_token',
+                'refresh_token' => $refreshToken,
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+            ]
+        ]);
+
+        $response = json_decode($response->getBody(), true);
+
+        return (new Token)
+            ->setToken(Arr::get($response, 'access_token'))
+            ->setRefreshToken(Arr::get($response, 'refresh_token'))
+            ->setExpiresIn(Arr::get($response, 'expires_in'))
+            ->setApprovedScopes(explode($this->scopeSeparator, Arr::get($response, 'scope', '')));
+    }
+
+    /**
      * Get the code from the request.
      *
      * @return string

--- a/src/Two/Token.php
+++ b/src/Two/Token.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Laravel\Socialite\Two;
+
+class Token
+{
+    /**
+     * The user's access token.
+     *
+     * @var string
+     */
+    public $token;
+
+    /**
+     * The refresh token that can be exchanged for a new access token.
+     *
+     * @var string
+     */
+    public $refreshToken;
+
+    /**
+     * The number of seconds the access token is valid for.
+     *
+     * @var int
+     */
+    public $expiresIn;
+
+    /**
+     * The scopes the user authorized. The approved scopes may be a subset of the requested scopes.
+     *
+     * @var array
+     */
+    public $approvedScopes;
+
+    /**
+     * Set the token on the user.
+     *
+     * @param  string  $token
+     * @return $this
+     */
+    public function setToken($token)
+    {
+        $this->token = $token;
+
+        return $this;
+    }
+
+    /**
+     * Set the refresh token required to obtain a new access token.
+     *
+     * @param  string  $refreshToken
+     * @return $this
+     */
+    public function setRefreshToken($refreshToken)
+    {
+        $this->refreshToken = $refreshToken;
+
+        return $this;
+    }
+
+    /**
+     * Set the number of seconds the access token is valid for.
+     *
+     * @param  int  $expiresIn
+     * @return $this
+     */
+    public function setExpiresIn($expiresIn)
+    {
+        $this->expiresIn = $expiresIn;
+
+        return $this;
+    }
+
+    /**
+     * Set the scopes that were approved by the user during authentication.
+     *
+     * @param  array  $approvedScopes
+     * @return $this
+     */
+    public function setApprovedScopes($approvedScopes)
+    {
+        $this->approvedScopes = $approvedScopes;
+
+        return $this;
+    }
+}

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -10,6 +10,7 @@ use Laravel\Socialite\Tests\Fixtures\FacebookTestProviderStub;
 use Laravel\Socialite\Tests\Fixtures\OAuthTwoTestProviderStub;
 use Laravel\Socialite\Tests\Fixtures\OAuthTwoWithPKCETestProviderStub;
 use Laravel\Socialite\Two\InvalidStateException;
+use Laravel\Socialite\Two\Token;
 use Laravel\Socialite\Two\User;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -177,5 +178,24 @@ class OAuthTwoTest extends TestCase
         $session->expects('pull')->with('state');
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect');
         $provider->user();
+    }
+
+    public function testUserRefreshesToken()
+    {
+        $request = Request::create('/');
+        $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
+        $provider->http = m::mock(stdClass::class);
+        $provider->http->expects('post')->with('http://token.url', [
+            'headers' => ['Accept' => 'application/json'],
+            'form_params' => ['grant_type' => 'refresh_token', 'client_id' => 'client_id', 'client_secret' => 'client_secret', 'refresh_token' => 'refresh_token'],
+        ])->andReturns($response = m::mock(stdClass::class));
+        $response->expects('getBody')->andReturns('{ "access_token" : "access_token", "refresh_token" : "refresh_token", "expires_in" : 3600, "scope" : "scope1,scope2" }');
+        $tokenResponse = $provider->refreshToken('refresh_token');
+
+        $this->assertInstanceOf(Token::class, $tokenResponse);
+        $this->assertSame('access_token', $tokenResponse->token);
+        $this->assertSame('refresh_token', $tokenResponse->refreshToken);
+        $this->assertSame(3600, $tokenResponse->expiresIn);
+        $this->assertSame(['scope1', 'scope2'], $tokenResponse->approvedScopes);
     }
 }


### PR DESCRIPTION
This PR introduces a `refreshToken` method for OAuth 2.0 providers.

Typically, access tokens are updated in the database each time a user logs in. However, this approach may not be adequate for applications that perform actions on behalf of users, such as fetching data from social channels. There are scenarios where the user's session outlasts the token's validity, or where the application needs to use the token without the user's active login.

To address this, the proposed `refreshToken` method enables the application to refresh access tokens at any time using stored refresh tokens. 

```php
$newToken = Socialite::driver('gitlab')->refreshToken($user->gitlab_refresh_token);

$user->update([
    'gitlab_token' => $newToken->token,
    'gitlab_refresh_token' => $newToken->refreshToken,
    'gitlab_token_expires_at' => now()->addSeconds($newToken->expiresIn),
]);
```

The method returns an instance of the `Token` class, which includes the refreshed access token, refresh token, expiration duration, and scope.