### PR TITLE
Added expiresAt Carbon attribute to OAuth2 token class

### DIFF
--- a/src/Two/Token.php
+++ b/src/Two/Token.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Socialite\Two;
 
+use Illuminate\Support\Carbon;
+
 class Token
 {
     /**
@@ -26,6 +28,13 @@ class Token
     public $expiresIn;
 
     /**
+     * The date when the access token expires.
+     *
+     * @var Carbon
+     */
+    public $expiresAt;
+
+    /**
      * The scopes the user authorized. The approved scopes may be a subset of the requested scopes.
      *
      * @var array
@@ -45,6 +54,7 @@ class Token
         $this->token = $token;
         $this->refreshToken = $refreshToken;
         $this->expiresIn = $expiresIn;
+        $this->expiresAt = Carbon::now()->addSeconds($expiresIn);
         $this->approvedScopes = $approvedScopes;
     }
 }


### PR DESCRIPTION
This is a helper attribute which I've added in my own usage of Socialite when working with `expires_at` which are plain integers.

Having a `Carbon` object readily available is useful when storing tokens in a database and working with refreshing tokens in commands.