### PR TITLE
[5.x] Adding basic authentication by default on signed routes

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -314,7 +314,10 @@ abstract class AbstractProvider implements ProviderContract
      */
     protected function getTokenHeaders($code)
     {
-        return ['Accept' => 'application/json'];
+        return [
+            'Accept' => 'application/json',
+            'Authorization' => 'Basic '.base64_encode($this->clientId.':'.$this->clientSecret),
+        ];
     }
 
     /**

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -102,7 +102,7 @@ class OAuthTwoTest extends TestCase
         $provider = new OAuthTwoWithPKCETestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock(stdClass::class);
         $provider->http->expects('post')->with('http://token.url', [
-            'headers' => ['Accept' => 'application/json'], 'form_params' => ['grant_type' => 'authorization_code', 'client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri', 'code_verifier' => $codeVerifier],
+            'headers' => ['Accept' => 'application/json', 'Authorization' => 'Basic '.base64_encode('client_id:client_secret')], 'form_params' => ['grant_type' => 'authorization_code', 'client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri', 'code_verifier' => $codeVerifier],
         ])->andReturns($response = m::mock(stdClass::class));
         $response->expects('getBody')->andReturns('{ "access_token" : "access_token", "refresh_token" : "refresh_token", "expires_in" : 3600 }');
         $user = $provider->user();
@@ -123,7 +123,7 @@ class OAuthTwoTest extends TestCase
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock(stdClass::class);
         $provider->http->expects('post')->with('http://token.url', [
-            'headers' => ['Accept' => 'application/json'], 'form_params' => ['grant_type' => 'authorization_code', 'client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
+            'headers' => ['Accept' => 'application/json', 'Authorization' => 'Basic '.base64_encode('client_id:client_secret')], 'form_params' => ['grant_type' => 'authorization_code', 'client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
         ])->andReturns($response = m::mock(stdClass::class));
         $response->expects('getBody')->andReturns('{ "access_token" : "access_token", "refresh_token" : "refresh_token", "expires_in" : 3600 }');
         $user = $provider->user();


### PR DESCRIPTION
According to [RFC-6749](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1) clients can choose from a number of authentication methods to authenticate with the authorization server.

Section 2.3.1 states that clients can put the credentials either as a Basic authorization header or passing the credentials in the body of the POST.

Right now, the default method for Socialite (in AbstractProvider) is to pass the credentials in the body of the POST.

However, the spec states this:

> Including the client credentials in the request-body using the two parameters is NOT RECOMMENDED and SHOULD be limited to clients unable
> to directly utilize the HTTP Basic authentication scheme (or other
> password-based HTTP authentication schemes).

So Socialite passes the credentials using the "non recommended" way.

Furthermore, this way of passing the credentials in NOT supported by all servers. However, the Basic authentication method is mandated to be compulsory per the spec:

> The authorization server MUST support the HTTP Basic
> authentication scheme for authenticating clients that were issued a
> client password.

As a result, a number of providers need to manually add the Basic authentication as you can see from a simple Github search on the "Providers" Github repository:

https://github.com/search?q=repo%3ASocialiteProviders%2FProviders%20Basic&type=code

It would be better to use by default the only authentication scheme that we know (for sure) is supported by all servers.

This commit adds Basic authentication header to the requests created by the `AbstractProvider`.

It does not remove the parameters in the body in order to limit breaking changes.