### PR TITLE
Correct issue with Google refreshToken() method.

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -62,6 +62,21 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
+    public function refreshToken($refreshToken)
+    {
+        $response = $this->getRefreshTokenResponse($refreshToken);
+
+        return new Token(
+            Arr::get($response, 'access_token'),
+            Arr::get($response, 'refresh_token', $refreshToken),
+            Arr::get($response, 'expires_in'),
+            explode($this->scopeSeparator, Arr::get($response, 'scope', ''))
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function mapUserToObject(array $user)
     {
         // Deprecated: Fields added to keep backwards compatibility in 4.0. These will be removed in 5.0

--- a/tests/Fixtures/GoogleTestProviderStub.php
+++ b/tests/Fixtures/GoogleTestProviderStub.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Laravel\Socialite\Tests\Fixtures;
+
+use Laravel\Socialite\Two\GoogleProvider;
+use Laravel\Socialite\Two\User;
+use Mockery as m;
+use stdClass;
+
+class GoogleTestProviderStub extends GoogleProvider
+{
+    /**
+     * @var \GuzzleHttp\Client|\Mockery\MockInterface
+     */
+    public $http;
+
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('http://auth.url', $state);
+    }
+
+    protected function getTokenUrl()
+    {
+        return 'http://token.url';
+    }
+
+    protected function getUserByToken($token)
+    {
+        return ['id' => 'foo'];
+    }
+
+    protected function mapUserToObject(array $user)
+    {
+        return (new User)->map(['id' => $user['id']]);
+    }
+
+    /**
+     * Get a fresh instance of the Guzzle HTTP client.
+     *
+     * @return \GuzzleHttp\Client|\Mockery\MockInterface
+     */
+    protected function getHttpClient()
+    {
+        if ($this->http) {
+            return $this->http;
+        }
+
+        return $this->http = m::mock(stdClass::class);
+    }
+}


### PR DESCRIPTION
Fixes: #683 

---

When issuing a refreshToken call with Google - you don't get a new refresh token. You are expected to keep the original one. At the moment Socialite makes an assumption that you will - thus crashes with:

```
Laravel\Socialite\Two\Token::__construct(): Argument 2 ($refreshToken) must be of type string, null given, called in vendor/laravel/socialite/src/Two/AbstractProvider.php on line 353.
```

Overrode `refreshToken` with specific implementation on Google, then added a test.
