### PR TITLE
fix(google provider): check if response body of GoogleProvider's getU…

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Socialite\Two;
 
+use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 
@@ -55,6 +56,10 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
                 'Authorization' => 'Bearer '.$token,
             ],
         ]);
+
+        if ($response->getBody() instanceof Stream) {
+            return json_decode($response->getBody()->getContents(), true);
+        }
 
         return json_decode($response->getBody(), true);
     }


### PR DESCRIPTION
…serByToken method is a GuzzleHttp\Psr7\Stream instance

Fix `TypeError` error caused on `GoogleProvider`'s `getUserByToken` method when trying to `json_decode` the response body.