### PR TITLE
Correct issue with GoogleProvider getUserByToken() method

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Socialite\Two;
 
+use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 
@@ -55,6 +56,10 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
                 'Authorization' => 'Bearer '.$token,
             ],
         ]);
+
+        if ($response->getBody() instanceof Stream) {
+            return json_decode($response->getBody()->getContents(), true);
+        }
 
         return json_decode($response->getBody(), true);
     }

--- a/tests/GoogleProviderTest.php
+++ b/tests/GoogleProviderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Laravel\Socialite\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use Illuminate\Http\Request;
+use Laravel\Socialite\Tests\Fixtures\GoogleTestProviderStub;
+use Laravel\Socialite\Two\User;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class GoogleProviderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    public function test_it_can_map_a_user_from_an_access_token()
+    {
+        $request = Request::create('/');
+
+        $provider = new GoogleTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
+
+        $provider->http = m::mock(Client::class);
+
+        $provider->http->allows('get')->with('https://www.googleapis.com/oauth2/v3/userinfo', [
+            RequestOptions::QUERY => [
+                'prettyPrint' => 'false',
+            ],
+            RequestOptions::HEADERS => [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer fake-token',
+            ],
+        ])->andReturns($response = m::mock(ResponseInterface::class));
+
+        $response->allows('getBody')->andReturns(m::mock(StreamInterface::class));
+
+        $user = $provider->userFromToken('fake-token');
+
+        $this->assertInstanceOf(User::class, $user);
+    }
+}


### PR DESCRIPTION
Calling `getUserByToken` from `GoogleProvider` crashes with:

```bash
TypeError error json_decode(): Argument #1 ($json) must be of type string, GuzzleHttp\Psr7\Stream given.
```

To handle this situation, added this code in `getUserByToken` method:

```php
  if ($response->getBody() instanceof Stream) {
      return json_decode($response->getBody()->getContents(), true);
  }
```

Finally, test added to check method works as expected.