### PR TITLE
set nickname to null in GoogleProvider

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -91,7 +91,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
 
         return (new User)->setRaw($user)->map([
             'id' => Arr::get($user, 'sub'),
-            'nickname' => Arr::get($user, 'nickname'),
+            'nickname' => null,
             'name' => Arr::get($user, 'name'),
             'email' => Arr::get($user, 'email'),
             'avatar' => $avatarUrl = Arr::get($user, 'picture'),


### PR DESCRIPTION
<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
The benefit of this pull request is to prevent devs from having to debug why `nickname` is set to null in the GoogleProvider. 

Issue ticket is here; https://github.com/laravel/socialite/issues/690

I followed the convention set in [src/Two/LinkedInOpenIdProvider.php:75](https://github.com/laravel/socialite/blob/d1895614479c2e189e0292f12e59b1dd614eeea9/src/Two/LinkedInOpenIdProvider.php#L75)
