### PR TITLE
Support OIDC token in Facebook provider (Facebook Limited Login)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,13 @@
     "require": {
         "php": "^7.2|^8.0",
         "ext-json": "*",
+        "firebase/php-jwt": "^6.10",
         "guzzlehttp/guzzle": "^6.0|^7.0",
         "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "illuminate/http": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "league/oauth1-client": "^1.10.1"
+        "league/oauth1-client": "^1.10.1",
+        "phpseclib/phpseclib": "^3.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "ext-json": "*",
-        "firebase/php-jwt": "^6.10",
+        "firebase/php-jwt": "^6.4",
         "guzzlehttp/guzzle": "^6.0|^7.0",
         "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "illuminate/http": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -186,7 +186,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
             $avatarOriginalUrl = $avatarUrl.'?width=1920';
         }
 
-        return (new User())->setRaw($user)->map([
+        return (new User)->setRaw($user)->map([
             'id' => $user['id'],
             'nickname' => null,
             'name' => $user['name'] ?? null,

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -7,7 +7,6 @@ use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
 use phpseclib3\Crypt\RSA;
 use phpseclib3\Math\BigInteger;
 
@@ -103,7 +102,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
             ?? $this->getUserFromAccessToken($token);
     }
 
-    protected function getUserByOIDCToken($token) : ?array
+    protected function getUserByOIDCToken($token)
     {
         $kid = json_decode(base64_decode(explode('.', $token)[0]), true)['kid'] ?? null;
 
@@ -123,7 +122,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
         return $data;
     }
 
-    protected function getPublicKeyOfOIDCToken(string $kid) : Key
+    protected function getPublicKeyOfOIDCToken(string $kid)
     {
         $response = $this->getHttpClient()->get('https://limited.facebook.com/.well-known/oauth/openid/jwks/');
 

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -98,8 +98,8 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     {
         $this->lastToken = $token;
 
-        return $this->getUserByOIDCToken($token)
-            ?? $this->getUserFromAccessToken($token);
+        return $this->getUserByOIDCToken($token) ??
+               $this->getUserFromAccessToken($token);
     }
 
     /**
@@ -118,8 +118,8 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
 
         $data = (array) JWT::decode($token, $this->getPublicKeyOfOIDCToken($kid));
 
-        throw_if($data['aud'] !== $this->clientId, new Exception('Token has incorrect audience'));
-        throw_if($data['iss'] !== 'https://www.facebook.com', new Exception('Token has incorrect issuer'));
+        throw_if($data['aud'] !== $this->clientId, new Exception('Token has incorrect audience.'));
+        throw_if($data['iss'] !== 'https://www.facebook.com', new Exception('Token has incorrect issuer.'));
 
         $data['id'] = $data['sub'];
         $data['first_name'] = $data['given_name'];
@@ -129,7 +129,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     }
 
     /**
-     * Get public key to verify the signature of OIDC token.
+     * Get the public key to verify the signature of OIDC token.
      *
      * @param  string  $id
      * @return \Firebase\JWT\Key
@@ -182,6 +182,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     {
         if (! isset($user['sub'])) {
             $avatarUrl = $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture';
+
             $avatarOriginalUrl = $avatarUrl.'?width=1920';
         }
 

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -2,8 +2,14 @@
 
 namespace Laravel\Socialite\Two;
 
+use Exception;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Math\BigInteger;
 
 class FacebookProvider extends AbstractProvider implements ProviderInterface
 {
@@ -93,6 +99,46 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     {
         $this->lastToken = $token;
 
+        return $this->getUserByOIDCToken($token)
+            ?? $this->getUserFromAccessToken($token);
+    }
+
+    protected function getUserByOIDCToken($token) : ?array
+    {
+        $kid = json_decode(base64_decode(explode('.', $token)[0]), true)['kid'] ?? null;
+
+        if ($kid === null) {
+            return null;
+        }
+
+        $data = (array) JWT::decode($token, $this->getPublicKeyOfOIDCToken($kid));
+
+        throw_if($data['aud'] !== $this->clientId, new Exception('Token has incorrect audience'));
+        throw_if($data['iss'] !== 'https://www.facebook.com', new Exception('Token has incorrect issuer'));
+
+        $data['id'] = $data['sub'];
+        $data['first_name'] = $data['given_name'];
+        $data['last_name'] = $data['family_name'];
+
+        return $data;
+    }
+
+    protected function getPublicKeyOfOIDCToken(string $kid) : Key
+    {
+        $response = $this->getHttpClient()->get('https://limited.facebook.com/.well-known/oauth/openid/jwks/');
+
+        $key = Arr::first(json_decode($response->getBody()->getContents(), true)['keys'], function ($key) use ($kid) {
+            return $key['kid'] === $kid;
+        });
+
+        $key['n'] = new BigInteger(JWT::urlsafeB64Decode($key['n']), 256);
+        $key['e'] = new BigInteger(JWT::urlsafeB64Decode($key['e']), 256);
+
+        return new Key((string) RSA::load($key), 'RS256');
+    }
+
+    protected function getUserFromAccessToken($token)
+    {
         $params = [
             'access_token' => $token,
             'fields' => implode(',', $this->fields),
@@ -117,15 +163,18 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user)
     {
-        $avatarUrl = $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture';
+        if (! isset($user['sub'])) {
+            $avatarUrl = $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture';
+            $avatarOriginalUrl = $avatarUrl.'?width=1920';
+        }
 
-        return (new User)->setRaw($user)->map([
+        return (new User())->setRaw($user)->map([
             'id' => $user['id'],
             'nickname' => null,
             'name' => $user['name'] ?? null,
             'email' => $user['email'] ?? null,
-            'avatar' => $avatarUrl.'?type=normal',
-            'avatar_original' => $avatarUrl.'?width=1920',
+            'avatar' => $avatarUrl ?? $user['picture'] ?? null,
+            'avatar_original' => $avatarOriginalUrl ?? $user['picture'] ?? null,
             'profileUrl' => $user['link'] ?? null,
         ]);
     }

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -102,6 +102,12 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
             ?? $this->getUserFromAccessToken($token);
     }
 
+    /**
+     * Get user based on the OIDC token.
+     *
+     * @param  string  $token
+     * @return array
+     */
     protected function getUserByOIDCToken($token)
     {
         $kid = json_decode(base64_decode(explode('.', $token)[0]), true)['kid'] ?? null;
@@ -122,6 +128,12 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
         return $data;
     }
 
+    /**
+     * Get public key to verify the signature of OIDC token.
+     *
+     * @param  string  $id
+     * @return \Firebase\JWT\Key
+     */
     protected function getPublicKeyOfOIDCToken(string $kid)
     {
         $response = $this->getHttpClient()->get('https://limited.facebook.com/.well-known/oauth/openid/jwks/');
@@ -136,6 +148,12 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
         return new Key((string) RSA::load($key), 'RS256');
     }
 
+    /**
+     * Get user based on the access token.
+     *
+     * @param  string  $token
+     * @return array
+     */
     protected function getUserFromAccessToken($token)
     {
         $params = [


### PR DESCRIPTION
Facebook recently made changes to its Facebook Login on iOS: https://developers.facebook.com/blog/post/2024/03/28/changes-made-to-fb-login-sdk/

When a user does not allow app tracking, the login uses a new 'limited login' flow that returns an OIDC token. This token can not be used to access Facebook's Graph API. That means the current Facebook provider does not work in this 'limited login' flow. Apple requires you to use Facebook's latest SDK version.  That SDK version uses this new 'limited login' flow. This makes the current Facebook socialite provider unusable when validating a Facebook login via iOS SDK.

This PR fixes that by adding support for the OIDC token in a way that does not break or impact the regular Facebook login.

I implemented the validation of the OIDC token based on Facebook's documentation: https://developers.facebook.com/docs/facebook-login/limited-login/token/validating

Example of a user returned from the `userFromToken()` method when an OIDC token was provided:
<img width="1289" alt="Screenshot 2024-04-12 at 13 49 59" src="https://github.com/laravel/socialite/assets/22586858/ca4f60bd-a933-4c20-8bd8-f5b1ea9b6141">

I did not add tests as I don't really see a way how I can write a test for this.