### PR TITLE
Correct issue with GoogleProvider getUserByToken() method

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Socialite\Two;
 
-use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -57,11 +57,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
             ],
         ]);
 
-        if ($response->getBody() instanceof Stream) {
-            return json_decode($response->getBody()->getContents(), true);
-        }
-
-        return json_decode($response->getBody(), true);
+        return json_decode((string) $response->getBody(), true);
     }
 
     /**


### PR DESCRIPTION
Calling **`getUserByToken`** twice from GoogleProvider will result in obtaining null value for the second call. If you directly use `getContents()` from `GuzzleHttp\Psr7\Stream` to retrieve values, after the first retrieval, you need to execute `seek(0)` to reset the pointer position to the beginning. This is necessary for the second retrieval to work properly. `__toString()` handles this internally.

Scenario :
When using the **`GuzzleHttp\Client`** class, I've implemented a **`LogMiddleware`**. This middleware is primarily for logging the `request body` and `response body` of each API call. Consequently, during logging, `getContents` is executed once, leading to `getContents` during the return of `getUserByToken` actually receiving null.