### PR TITLE
[5.x] Add Slack OpenID provider

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -14,6 +14,7 @@ use Laravel\Socialite\Two\GitlabProvider;
 use Laravel\Socialite\Two\GoogleProvider;
 use Laravel\Socialite\Two\LinkedInOpenIdProvider;
 use Laravel\Socialite\Two\LinkedInProvider;
+use Laravel\Socialite\Two\SlackOpenIdProvider;
 use Laravel\Socialite\Two\SlackProvider;
 use Laravel\Socialite\Two\TwitterProvider as TwitterOAuth2Provider;
 use League\OAuth1\Client\Server\Twitter as TwitterServer;
@@ -181,6 +182,20 @@ class SocialiteManager extends Manager implements Contracts\Factory
 
         return $this->buildProvider(
             SlackProvider::class, $config
+        );
+    }
+
+    /**
+     * Create an instance of the specified driver.
+     *
+     * @return \Laravel\Socialite\Two\AbstractProvider
+     */
+    protected function createSlackOpenidDriver()
+    {
+        $config = $this->config->get('services.slack-openid');
+
+        return $this->buildProvider(
+            SlackOpenIdProvider::class, $config
         );
     }
 

--- a/src/Two/SlackOpenIdProvider.php
+++ b/src/Two/SlackOpenIdProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Socialite\Two;
+
+use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Arr;
+
+class SlackOpenIdProvider extends AbstractProvider implements ProviderInterface
+{
+    protected $scopes = ['openid', 'email', 'profile'];
+
+    protected $scopeSeparator = ' ';
+
+    protected function getAuthUrl($state): string
+    {
+        return $this->buildAuthUrlFromBase('https://slack.com/openid/connect/authorize', $state);
+    }
+
+    protected function getTokenUrl(): string
+    {
+        return 'https://slack.com/api/openid.connect.token';
+    }
+
+    protected function getUserByToken($token): array
+    {
+        $response = $this->getHttpClient()->get('https://slack.com/api/openid.connect.userInfo', [
+            RequestOptions::HEADERS => ['Authorization' => 'Bearer '.$token],
+        ]);
+
+        return json_decode($response->getBody()->getContents(), true);
+    }
+
+    protected function mapUserToObject(array $user): User
+    {
+        return (new User)->setRaw($user)->map([
+            'id' => Arr::get($user, 'sub'),
+            'name' => Arr::get($user, 'name'),
+            'email' => Arr::get($user, 'email'),
+            'avatar' => Arr::get($user, 'picture'),
+            'organization_id' => Arr::get($user, 'https://slack.com/team_id'),
+        ]);
+    }
+}

--- a/src/Two/SlackOpenIdProvider.php
+++ b/src/Two/SlackOpenIdProvider.php
@@ -36,6 +36,7 @@ class SlackOpenIdProvider extends AbstractProvider implements ProviderInterface
     {
         return (new User)->setRaw($user)->map([
             'id' => Arr::get($user, 'sub'),
+            'nickname' => null,
             'name' => Arr::get($user, 'name'),
             'email' => Arr::get($user, 'email'),
             'avatar' => Arr::get($user, 'picture'),

--- a/src/Two/SlackOpenIdProvider.php
+++ b/src/Two/SlackOpenIdProvider.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Laravel\Socialite\Two;
 
 use GuzzleHttp\RequestOptions;

--- a/src/Two/SlackOpenIdProvider.php
+++ b/src/Two/SlackOpenIdProvider.php
@@ -13,17 +13,17 @@ class SlackOpenIdProvider extends AbstractProvider implements ProviderInterface
 
     protected $scopeSeparator = ' ';
 
-    protected function getAuthUrl($state): string
+    protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://slack.com/openid/connect/authorize', $state);
     }
 
-    protected function getTokenUrl(): string
+    protected function getTokenUrl()
     {
         return 'https://slack.com/api/openid.connect.token';
     }
 
-    protected function getUserByToken($token): array
+    protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get('https://slack.com/api/openid.connect.userInfo', [
             RequestOptions::HEADERS => ['Authorization' => 'Bearer '.$token],
@@ -32,7 +32,7 @@ class SlackOpenIdProvider extends AbstractProvider implements ProviderInterface
         return json_decode($response->getBody()->getContents(), true);
     }
 
-    protected function mapUserToObject(array $user): User
+    protected function mapUserToObject(array $user)
     {
         return (new User)->setRaw($user)->map([
             'id' => Arr::get($user, 'sub'),

--- a/src/Two/SlackOpenIdProvider.php
+++ b/src/Two/SlackOpenIdProvider.php
@@ -27,7 +27,7 @@ class SlackOpenIdProvider extends AbstractProvider implements ProviderInterface
             RequestOptions::HEADERS => ['Authorization' => 'Bearer '.$token],
         ]);
 
-        return json_decode($response->getBody()->getContents(), true);
+        return json_decode($response->getBody(), true);
     }
 
     protected function mapUserToObject(array $user)

--- a/src/Two/SlackOpenIdProvider.php
+++ b/src/Two/SlackOpenIdProvider.php
@@ -7,20 +7,39 @@ use Illuminate\Support\Arr;
 
 class SlackOpenIdProvider extends AbstractProvider implements ProviderInterface
 {
+    /**
+     * The scopes being requested.
+     *
+     * @var array
+     */
     protected $scopes = ['openid', 'email', 'profile'];
 
+    /**
+     * The separating character for the requested scopes.
+     *
+     * @var string
+     */
     protected $scopeSeparator = ' ';
 
+    /**
+     * {@inheritdoc}
+     */
     protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase('https://slack.com/openid/connect/authorize', $state);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function getTokenUrl()
     {
         return 'https://slack.com/api/openid.connect.token';
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get('https://slack.com/api/openid.connect.userInfo', [
@@ -30,6 +49,9 @@ class SlackOpenIdProvider extends AbstractProvider implements ProviderInterface
         return json_decode($response->getBody(), true);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function mapUserToObject(array $user)
     {
         return (new User)->setRaw($user)->map([

--- a/tests/SlackOpenIdProviderTest.php
+++ b/tests/SlackOpenIdProviderTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use Illuminate\Http\Request;
+use Laravel\Socialite\Contracts\User as UserContract;
+use Laravel\Socialite\Two\SlackOpenIdProvider;
+use Laravel\Socialite\Two\User;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class SlackOpenIdProviderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    public function test_response()
+    {
+        $user = $this->fromResponse([
+            'sub' => 'U1Q2W3E4R5T',
+            'given_name' => 'Maarten',
+            'picture' => 'https://secure.gravatar.com/avatar/qwerty-123.jpg?s=512',
+            'name' => 'Maarten Paauw',
+            'family_name' => 'Paauw',
+            'email' => 'maarten.paauw@example.com',
+            'https://slack.com/team_id' => 'T0P9O8I7U6Y',
+        ]);
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertSame('U1Q2W3E4R5T', $user->getId());
+        $this->assertNull($user->getNickname());
+        $this->assertSame('Maarten Paauw', $user->getName());
+        $this->assertSame('maarten.paauw@example.com', $user->getEmail());
+        $this->assertSame('https://secure.gravatar.com/avatar/qwerty-123.jpg?s=512', $user->getAvatar());
+
+        $this->assertSame([
+            'id' => 'U1Q2W3E4R5T',
+            'nickname' => null,
+            'name' => 'Maarten Paauw',
+            'email' => 'maarten.paauw@example.com',
+            'avatar' => 'https://secure.gravatar.com/avatar/qwerty-123.jpg?s=512',
+            'organization_id' => 'T0P9O8I7U6Y',
+        ], $user->attributes);
+    }
+
+    public function test_missing_email_and_avatar()
+    {
+        $user = $this->fromResponse([
+            'sub' => 'U1Q2W3E4R5T',
+            'given_name' => 'Maarten',
+            'name' => 'Maarten Paauw',
+            'family_name' => 'Paauw',
+            'https://slack.com/team_id' => 'T0P9O8I7U6Y',
+        ]);
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertSame('U1Q2W3E4R5T', $user->getId());
+        $this->assertNull($user->getNickname());
+        $this->assertSame('Maarten Paauw', $user->getName());
+        $this->assertNull($user->getEmail());
+        $this->assertNull($user->getAvatar());
+
+        $this->assertSame([
+            'id' => 'U1Q2W3E4R5T',
+            'nickname' => null,
+            'name' => 'Maarten Paauw',
+            'email' => null,
+            'avatar' => null,
+            'organization_id' => 'T0P9O8I7U6Y',
+        ], $user->attributes);
+    }
+
+    protected function fromResponse(array $response): UserContract
+    {
+        $request = m::mock(Request::class);
+        $request->allows('input')->with('code')->andReturns('fake-code');
+
+        $stream = m::mock(StreamInterface::class);
+        $stream->allows('__toString')->andReturns(json_encode(['access_token' => 'fake-token']));
+
+        $accessTokenResponse = m::mock(ResponseInterface::class);
+        $accessTokenResponse->allows('getBody')->andReturns($stream);
+
+        $basicProfileStream = m::mock(StreamInterface::class);
+        $basicProfileStream->allows('__toString')->andReturns(json_encode($response));
+
+        $basicProfileResponse = m::mock(ResponseInterface::class);
+        $basicProfileResponse->allows('getBody')->andReturns($basicProfileStream);
+
+        $guzzle = m::mock(Client::class);
+        $guzzle->expects('post')->andReturns($accessTokenResponse);
+        $guzzle->allows('get')->with('https://slack.com/api/openid.connect.userInfo', [
+            RequestOptions::HEADERS => [
+                'Authorization' => 'Bearer fake-token',
+            ],
+        ])->andReturns($basicProfileResponse);
+
+        $provider = new SlackOpenIdProvider($request, 'client_id', 'client_secret', 'redirect');
+        $provider->stateless();
+        $provider->setHttpClient($guzzle);
+
+        return $provider->user();
+    }
+}


### PR DESCRIPTION
This pull request adds a separate Slack OpenID provider. It follows the entire auth flow, documented by Slack at: https://api.slack.com/authentication/sign-in-with-slack#implementation

The name of the provider class and retrieving configuration is inspired based on the LinkedIn OpenID provider.

To try the new provider out, you have to create a Slack application with the user scopes `openid`, `profile` and `email`.

This pull request closes issue #702 