### PR TITLE
Support the custom parameters of the access token request

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -337,7 +337,7 @@ abstract class AbstractProvider implements ProviderContract
             $fields['code_verifier'] = $this->request->session()->pull('code_verifier');
         }
 
-        return $fields;
+        return array_merge($fields, $this->parameters);
     }
 
     /**


### PR DESCRIPTION
Currently, Laravel Socialite allows custom parameters to be added to the authentication request via the with method, providing flexibility to developers for handling various OAuth providers' unique requirements. However, there is no built-in support for adding custom parameters to the access token request.

### Usage
```
$parameters = ['custom_param' => 'value'];

return Socialite::driver('provider')
    ->with($parameters)
    ->stateless()
    ->user();
```
With this update, the with method will now ensure that the custom parameters are included in both the authentication and access token requests.

### Conclusion
This enhancement aligns the functionality of access token requests with that of authentication requests, providing a more cohesive and powerful toolset for developers using Laravel Socialite.