### PR TITLE
Additional Getter Methods For Retrieving User Information

### DIFF
--- a/src/AbstractUser.php
+++ b/src/AbstractUser.php
@@ -130,6 +130,16 @@ abstract class AbstractUser implements ArrayAccess, User
     }
 
     /**
+     * Get the user's attributes.
+     *
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
      * Map the given array onto the user's properties.
      *
      * @param  array  $attributes

--- a/src/Two/User.php
+++ b/src/Two/User.php
@@ -35,6 +35,16 @@ class User extends AbstractUser
     public $approvedScopes;
 
     /**
+     * Get the access token for the user.
+     *
+     * @return string
+     */
+    public function getToken()
+    {
+        return $this->token;
+    }
+
+    /**
      * Set the token on the user.
      *
      * @param  string  $token
@@ -45,6 +55,16 @@ class User extends AbstractUser
         $this->token = $token;
 
         return $this;
+    }
+
+    /**
+     * Get the refresh token for the user.
+     *
+     * @return string
+     */
+    public function getRefreshToken()
+    {
+        return $this->refreshToken;
     }
 
     /**
@@ -61,6 +81,16 @@ class User extends AbstractUser
     }
 
     /**
+     * Get the number of seconds the access token is valid for.
+     *
+     * @return int
+     */
+    public function getExpiresIn()
+    {
+        return $this->expiresIn;
+    }
+
+    /**
      * Set the number of seconds the access token is valid for.
      *
      * @param  int  $expiresIn
@@ -71,6 +101,16 @@ class User extends AbstractUser
         $this->expiresIn = $expiresIn;
 
         return $this;
+    }
+
+    /**
+     * Get the scopes that were approved by the user during authentication.
+     *
+     * @return array
+     */
+    public function getApprovedScopes()
+    {
+        return $this->approvedScopes;
     }
 
     /**

--- a/tests/OAuthOneTest.php
+++ b/tests/OAuthOneTest.php
@@ -67,6 +67,7 @@ class OAuthOneTest extends TestCase
         $this->assertSame('uid', $user->id);
         $this->assertSame('foo@bar.com', $user->email);
         $this->assertSame(['extra' => 'extra'], $user->user);
+        $this->assertSame($user->getAttributes(), $user->attributes);
     }
 
     public function testExceptionIsThrownWhenVerifierIsMissing()

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -114,6 +114,10 @@ class OAuthTwoTest extends TestCase
         $this->assertSame('refresh_token', $user->refreshToken);
         $this->assertSame(3600, $user->expiresIn);
         $this->assertSame($user->id, $provider->user()->id);
+        $this->assertSame($user->getAttributes(), $user->attributes);
+        $this->assertSame($user->getToken(), $user->token);
+        $this->assertSame($user->getRefreshToken(), $user->refreshToken);
+        $this->assertSame($user->getExpiresIn(), $user->expiresIn);
     }
 
     public function testUserReturnsAUserInstanceForTheAuthenticatedRequest()
@@ -135,6 +139,10 @@ class OAuthTwoTest extends TestCase
         $this->assertSame('refresh_token', $user->refreshToken);
         $this->assertSame(3600, $user->expiresIn);
         $this->assertSame($user->id, $provider->user()->id);
+        $this->assertSame($user->getAttributes(), $user->attributes);
+        $this->assertSame($user->getToken(), $user->token);
+        $this->assertSame($user->getRefreshToken(), $user->refreshToken);
+        $this->assertSame($user->getExpiresIn(), $user->expiresIn);
     }
 
     public function testUserReturnsAUserInstanceForTheAuthenticatedFacebookRequest()
@@ -156,6 +164,10 @@ class OAuthTwoTest extends TestCase
         $this->assertNull($user->refreshToken);
         $this->assertSame(5183085, $user->expiresIn);
         $this->assertSame($user->id, $provider->user()->id);
+        $this->assertSame($user->getAttributes(), $user->attributes);
+        $this->assertSame($user->getToken(), $user->token);
+        $this->assertSame($user->getRefreshToken(), $user->refreshToken);
+        $this->assertSame($user->getExpiresIn(), $user->expiresIn);
     }
 
     public function testExceptionIsThrownIfStateIsInvalid()


### PR DESCRIPTION
## Description

This PR updates the `Laravel\Socialite\AbstractUser` and `Laravel\Socialite\Two\User` classes to add additional getter methods. It also enhances the existing tests to verify that the new getter methods return the correct property values.

## Changes

### `AbstractUser` Class Updates

**New Getter Method:**

- `getAttributes`: Get the user's attributes.

### `Two\User` Class Updates:

**New Getter Methods:**

- `getToken`: Retrieves the user's access token.
- `getRefreshToken`: Retrieves the user's refresh token.
- `getExpiresIn`: Retrieves the number of seconds the access token is valid for.
- `getApprovedScopes`: Retrieves the scopes approved by the user during authentication.

### Tests:

- Updated the `OAuthOneTest` and `OAuthTwoTest` class to use the new getter methods.
- Added assertions to verify that the getter methods return the correct property values.

## Benefits to End Users

These updates provide more convenient methods for retrieving user information, making it easier to work with user data. The changes are backward-compatible and do not break any existing features. Note that while the `Two\User` getters enhance data retrieval, the properties still require type-hinting for full static analysis compatibility.