### PR TITLE
Add X Provider

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -17,6 +17,7 @@ use Laravel\Socialite\Two\LinkedInProvider;
 use Laravel\Socialite\Two\SlackOpenIdProvider;
 use Laravel\Socialite\Two\SlackProvider;
 use Laravel\Socialite\Two\TwitterProvider as TwitterOAuth2Provider;
+use Laravel\Socialite\Two\XProvider;
 use League\OAuth1\Client\Server\Twitter as TwitterServer;
 
 class SocialiteManager extends Manager implements Contracts\Factory
@@ -168,6 +169,20 @@ class SocialiteManager extends Manager implements Contracts\Factory
 
         return $this->buildProvider(
             TwitterOAuth2Provider::class, $config
+        );
+    }
+
+    /**
+     * Create an instance of the specified driver.
+     *
+     * @return \Laravel\Socialite\Two\AbstractProvider
+     */
+    protected function createXDriver()
+    {
+        $config = $this->config->get('services.x') ?? $this->config->get('services.x-oauth-2');
+
+        return $this->buildProvider(
+            XProvider::class, $config
         );
     }
 

--- a/src/Two/XProvider.php
+++ b/src/Two/XProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Laravel\Socialite\Two;
+
+use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Arr;
+
+class XProvider extends TwitterProvider
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase('https://x.com/i/oauth2/authorize', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return 'https://api.x.com/2/oauth2/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get('https://api.x.com/2/users/me', [
+            RequestOptions::HEADERS => ['Authorization' => 'Bearer '.$token],
+            RequestOptions::QUERY => ['user.fields' => 'profile_image_url'],
+        ]);
+
+        return Arr::get(json_decode($response->getBody(), true), 'data');
+    }
+}


### PR DESCRIPTION
X (formerly known as Twitter) currently redirects twitter.com to x.com. However, with OAuth 2.0 on X, when the authorization server redirects to twitter.com, the authorization screen still appears at twitter.com (https://twitter.com/i/oauth2/authorize). In this state, the session logged in on x.com is not shared, which may lead to authorization with a different account or require re-login.

Therefore, I have added a new OAuth 2.0 provider that redirects to x.com.

Thank you.