### PR TITLE
Add "email_verified" to linkedin openid

### DIFF
--- a/src/Two/LinkedInOpenIdProvider.php
+++ b/src/Two/LinkedInOpenIdProvider.php
@@ -58,7 +58,7 @@ class LinkedInOpenIdProvider extends AbstractProvider implements ProviderInterfa
                 'X-RestLi-Protocol-Version' => '2.0.0',
             ],
             RequestOptions::QUERY => [
-                'projection' => '(sub,email,name,given_name,family_name,picture)',
+                'projection' => '(sub,email,email_verified,name,given_name,family_name,picture)',
             ],
         ]);
 
@@ -77,6 +77,7 @@ class LinkedInOpenIdProvider extends AbstractProvider implements ProviderInterfa
             'first_name' => $user['given_name'],
             'last_name' => $user['family_name'],
             'email' => $user['email'] ?? null,
+            'email_verified' => $user['email_verified'] ?? null,
             'avatar' => $user['picture'] ?? null,
             'avatar_original' => $user['picture'] ?? null,
         ]);

--- a/tests/LinkedInOpenIdProviderTest.php
+++ b/tests/LinkedInOpenIdProviderTest.php
@@ -31,6 +31,7 @@ class LinkedInOpenIdProviderTest extends TestCase
             'name' => 'Nuno Maduro',
             'family_name' => 'Maduro',
             'email' => 'nuno@laravel.com',
+            'email_verified' => true,
         ]);
 
         $this->assertInstanceOf(User::class, $user);
@@ -47,6 +48,7 @@ class LinkedInOpenIdProviderTest extends TestCase
             'first_name' => 'Nuno',
             'last_name' => 'Maduro',
             'email' => 'nuno@laravel.com',
+            'email_verified' => true,
             'avatar' => 'https://media.licdn.com/dms/image/D4D03AQmZFgJNqeNNk',
             'avatar_original' => 'https://media.licdn.com/dms/image/D4D03AQmZFgJNqeNNk',
         ], $user->attributes);
@@ -75,6 +77,7 @@ class LinkedInOpenIdProviderTest extends TestCase
             'first_name' => 'Nuno',
             'last_name' => 'Maduro',
             'email' => null,
+            'email_verified' => null,
             'avatar' => null,
             'avatar_original' => null,
         ], $user->attributes);
@@ -105,7 +108,7 @@ class LinkedInOpenIdProviderTest extends TestCase
                 'X-RestLi-Protocol-Version' => '2.0.0',
             ],
             RequestOptions::QUERY => [
-                'projection' => '(sub,email,name,given_name,family_name,picture)',
+                'projection' => '(sub,email,email_verified,name,given_name,family_name,picture)',
             ],
         ])->andReturns($basicProfileResponse);
 


### PR DESCRIPTION
Linkedin [supports](https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2?context=linkedin%2Fconsumer%2Fcontext#api-request-to-retreive-member-details) an optional `email_verified` field but no way to manually set it.

The update does not require any extra permissions and shouldn't break any existing apps.