### PR TITLE
[5.x] Adds support for configuring Access Scope for providers from configuration

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -223,11 +223,11 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     public function buildProvider($provider, $config)
     {
-        return new $provider(
+        return (new $provider(
             $this->container->make('request'), $config['client_id'],
             $config['client_secret'], $this->formatRedirectUrl($config),
             Arr::get($config, 'guzzle', [])
-        );
+        ))->scopes($config['scopes'] ?? []);
     }
 
     /**

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -395,7 +395,7 @@ abstract class AbstractProvider implements ProviderContract
      */
     public function scopes($scopes)
     {
-        $this->scopes = array_unique(array_merge($this->scopes, (array) $scopes));
+        $this->scopes = array_values(array_unique(array_merge($this->scopes, (array) $scopes)));
 
         return $this;
     }
@@ -408,7 +408,7 @@ abstract class AbstractProvider implements ProviderContract
      */
     public function setScopes($scopes)
     {
-        $this->scopes = array_unique((array) $scopes);
+        $this->scopes = array_values(array_unique((array) $scopes));
 
         return $this;
     }

--- a/tests/SocialiteManagerTest.php
+++ b/tests/SocialiteManagerTest.php
@@ -31,4 +31,24 @@ class SocialiteManagerTest extends TestCase
 
         $this->assertInstanceOf(GithubProvider::class, $provider);
     }
+
+    public function test_it_can_instantiate_the_github_driver_with_scopes_from_config_array()
+    {
+        $factory = $this->app->make(Factory::class);
+        $this->app['config']->set('services.github', [
+            'client_id' => 'github-client-id',
+            'client_secret' => 'github-client-secret',
+            'redirect' => 'http://your-callback-url',
+            'scopes' => ['user:email', 'read:user'],
+        ]);
+        $provider = $factory->driver('github');
+        $this->assertSame(['user:email', 'read:user'], $provider->getScopes());
+    }
+
+    public function test_it_can_instantiate_the_github_driver_with_scopes_without_array_from_config()
+    {
+        $factory = $this->app->make(Factory::class);
+        $provider = $factory->driver('github');
+        $this->assertSame(['user:email'], $provider->getScopes());
+    }
 }


### PR DESCRIPTION
Hi All,

### Description
This PR adds support for easily **adding** Access Scopes for 0Auth Providers by specifying the `scopes` key in the application's `config/services.php` as shown below:

```
    'github' => [
        'client_id'     => env('GITHUB_CLIENT_ID'),
        'client_secret' => env('GITHUB_CLIENT_SECRET'),
        'redirect'      => env('GITHUB_REDIRECT_URI'),
        'scopes'        => ['read:user', 'user:email'],
    ],
```

Specified scopes are **merged** with the scopes already defined in the provider's class to ensure appropriate scopes are still submitted.

Tests written for default implementation and implementation with additional provided scopes.

### End User Benefits
Instead of needing to alter the default implementation as described in [The Official Documentation](https://laravel.com/docs/11.x/socialite#access-scopes), users can simply add an array key to their configuration for the same affect.


### Existing Features Considerations and Technical Notes

Updated SocialiteManager->buildProvider to initialise scopes from the configuration `services.{driver}.scopes` array if provided. 

Added tests to validate GitHub driver behaves correctly with and without `services.{driver}.scopes` array provided.

Ensured scopes are returned as indexed arrays without missing indexes by using `array_values` to prevent possible future implementation issues. 

Ensure backwards compatibility by wrapping provider instantiation in parenthesis when calling AbstractProvider->scopes() in SocialiteManager->buildProvider().




