### PR TITLE
Update facade PHPDoc

### DIFF
--- a/src/Facades/Socialite.php
+++ b/src/Facades/Socialite.php
@@ -7,7 +7,8 @@ use Laravel\Socialite\Contracts\Factory;
 
 /**
  * @method static \Laravel\Socialite\Contracts\Provider driver(string $driver = null)
- * @method static \Laravel\Socialite\Two\AbstractProvider buildProvider($provider, $config)
+ * @method static \Laravel\Socialite\Two\AbstractProvider buildProvider(string $provider, array $config)
+ * @method static \Laravel\Socialite\SocialiteManager extend(string $driver, \Closure $callback)
  * @method array getScopes()
  * @method \Laravel\Socialite\Contracts\Provider scopes(array|string $scopes)
  * @method \Laravel\Socialite\Contracts\Provider setScopes(array|string $scopes)


### PR DESCRIPTION
Changes to facade PHPDoc:
- Adds the missing `extend` method
- Introduces types to `buildProvider`