### PR TITLE
[5.x] Throw exception if config is incomplete

### DIFF
--- a/src/Exceptions/DriverMissingConfigurationException.php
+++ b/src/Exceptions/DriverMissingConfigurationException.php
@@ -9,12 +9,12 @@ class DriverMissingConfigurationException extends InvalidArgumentException
     /**
      * Create a new exception for a missing configuration.
      *
-     * @param  string  $driver
+     * @param  string  $provider
      * @param  array<int, string>  $keys
      * @return static
      */
-    public static function missingConfig($driver, $keys)
+    public static function make($provider, $keys)
     {
-        return new static("Missing required configuration keys [" . implode(', ', $keys) . "] for [{$driver}] OAuth provider.");
+        return new static("Missing required configuration keys [" . implode(', ', $keys) . "] for [{$provider}] OAuth provider.");
     }
 } 

--- a/src/Exceptions/DriverMissingConfigurationException.php
+++ b/src/Exceptions/DriverMissingConfigurationException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Socialite\Exceptions;
+
+use InvalidArgumentException;
+
+class DriverMissingConfigurationException extends InvalidArgumentException
+{
+    /**
+     * Create a new exception for a missing configuration.
+     *
+     * @param  string  $driver
+     * @param  array<int, string>  $keys
+     * @return static
+     */
+    public static function missingConfig($driver, $keys)
+    {
+        return new static("Missing required configuration keys [" . implode(', ', $keys) . "] for [{$driver}] OAuth provider.");
+    }
+} 

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Manager;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Laravel\Socialite\Exceptions\DriverMissingConfigurationException;
 use Laravel\Socialite\One\TwitterProvider;
 use Laravel\Socialite\Two\BitbucketProvider;
 use Laravel\Socialite\Two\FacebookProvider;
@@ -238,6 +239,13 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     public function buildProvider($provider, $config)
     {
+        $requiredKeys = ['client_id', 'client_secret', 'redirect'];
+        $missingKeys = array_diff($requiredKeys, array_keys($config ?? []));
+
+        if (! empty($missingKeys)) {
+            throw DriverMissingConfigurationException::missingConfig($provider, $missingKeys);
+        }
+
         return (new $provider(
             $this->container->make('request'), $config['client_id'],
             $config['client_secret'], $this->formatRedirectUrl($config),

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -243,7 +243,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
         $missingKeys = array_diff($requiredKeys, array_keys($config ?? []));
 
         if (! empty($missingKeys)) {
-            throw DriverMissingConfigurationException::missingConfig($provider, $missingKeys);
+            throw DriverMissingConfigurationException::make($provider, $missingKeys);
         }
 
         return (new $provider(

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -240,6 +240,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
     public function buildProvider($provider, $config)
     {
         $requiredKeys = ['client_id', 'client_secret', 'redirect'];
+
         $missingKeys = array_diff($requiredKeys, array_keys($config ?? []));
 
         if (! empty($missingKeys)) {

--- a/tests/SocialiteManagerTest.php
+++ b/tests/SocialiteManagerTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Socialite\Tests;
 
 use Laravel\Socialite\Contracts\Factory;
+use Laravel\Socialite\Exceptions\DriverMissingConfigurationException;
 use Laravel\Socialite\SocialiteServiceProvider;
 use Laravel\Socialite\Two\GithubProvider;
 use Orchestra\Testbench\TestCase;
@@ -76,5 +77,62 @@ class SocialiteManagerTest extends TestCase
         ]);
         $provider = $factory->driver('github')->setScopes(['read:user']);
         $this->assertSame(['read:user'], $provider->getScopes());
+    }
+
+    public function test_it_throws_exception_when_client_secret_is_missing()
+    {
+        $this->expectException(DriverMissingConfigurationException::class);
+        $this->expectExceptionMessage('Missing required configuration keys [client_secret] for [Laravel\Socialite\Two\GithubProvider] OAuth provider.');
+
+        $factory = $this->app->make(Factory::class);
+
+        $this->app['config']->set('services.github', [
+            'client_id' => 'github-client-id',
+            'redirect' => 'http://your-callback-url',
+        ]);
+        
+        $factory->driver('github');
+    }
+
+    public function test_it_throws_exception_when_client_id_is_missing()
+    {
+        $this->expectException(DriverMissingConfigurationException::class);
+        $this->expectExceptionMessage('Missing required configuration keys [client_id] for [Laravel\Socialite\Two\GithubProvider] OAuth provider.');
+
+        $factory = $this->app->make(Factory::class);
+
+        $this->app['config']->set('services.github', [
+            'client_secret' => 'github-client-secret',
+            'redirect' => 'http://your-callback-url',
+        ]);
+
+        $factory->driver('github');
+    }
+
+    public function test_it_throws_exception_when_redirect_is_missing()
+    {
+        $this->expectException(DriverMissingConfigurationException::class);
+        $this->expectExceptionMessage('Missing required configuration keys [redirect] for [Laravel\Socialite\Two\GithubProvider] OAuth provider.');
+
+        $factory = $this->app->make(Factory::class);
+
+        $this->app['config']->set('services.github', [
+            'client_id' => 'github-client-id',
+            'client_secret' => 'github-client-secret',
+        ]);
+
+        $factory->driver('github');
+    }
+
+    public function test_it_throws_exception_when_configuration_is_completely_missing()
+    {
+        $this->expectException(DriverMissingConfigurationException::class);
+        $this->expectExceptionMessage('Missing required configuration keys [client_id, client_secret, redirect] for [Laravel\Socialite\Two\GithubProvider] OAuth provider.');
+
+        $factory = $this->app->make(Factory::class);
+
+        $this->app['config']->set('services.github', null);
+
+        $factory->driver('github');
     }
 }


### PR DESCRIPTION
(This is a breaking change, but I'd consider this a bug fix)

While watching Prime's stream with Taylor and TJ, their oAuth implementation was failing because the `twitch` config was incomplete. 
Since it was trying to access an array key on a null variable, the warning was not informative at all (`Trying to access array offset on value of type null`). If you're experienced, you sorta know where to look for things, but if you're new this is very confusing.

Since `client_id`, `client_secret` and `redirect` are *always* expected, this PR simply throws an exception letting the user know what was missing exactly. 