### PR TITLE
Added email to X provider

### DIFF
--- a/src/Two/XProvider.php
+++ b/src/Two/XProvider.php
@@ -36,10 +36,15 @@ class XProvider extends TwitterProvider
         return Arr::get(json_decode($response->getBody(), true), 'data');
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function mapUserToObject(array $user)
     {
         $user = parent::mapUserToObject($user);
+
         $user->email = $user['confirmed_email'];
+
         return $user;
     }
 }

--- a/src/Two/XProvider.php
+++ b/src/Two/XProvider.php
@@ -30,9 +30,16 @@ class XProvider extends TwitterProvider
     {
         $response = $this->getHttpClient()->get('https://api.x.com/2/users/me', [
             RequestOptions::HEADERS => ['Authorization' => 'Bearer '.$token],
-            RequestOptions::QUERY => ['user.fields' => 'profile_image_url'],
+            RequestOptions::QUERY => ['user.fields' => 'profile_image_url,confirmed_email'],
         ]);
 
         return Arr::get(json_decode($response->getBody(), true), 'data');
+    }
+
+    protected function mapUserToObject(array $user)
+    {
+        $user = parent::mapUserToObject($user);
+        $user->email = $user['confirmed_email'];
+        return $user;
     }
 }


### PR DESCRIPTION
Currently, logging in with X doesn't return the email. On April 3rd, X has added email to OAuth2: https://devcommunity.x.com/t/announcing-support-for-email-address-retrieval-with-oauth-2-0-in-the-x-api-v2/240555

This PR adds it to the final user object.