### PR TITLE
Added email and it's scope to TwitterProvider

### DIFF
--- a/src/Two/TwitterProvider.php
+++ b/src/Two/TwitterProvider.php
@@ -57,7 +57,7 @@ class TwitterProvider extends AbstractProvider implements ProviderInterface
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get('https://api.twitter.com/2/users/me', [
-            RequestOptions::HEADERS => ['Authorization' => 'Bearer ' . $token],
+            RequestOptions::HEADERS => ['Authorization' => 'Bearer '.$token],
             RequestOptions::QUERY => ['user.fields' => 'profile_image_url,confirmed_email'],
         ]);
 

--- a/src/Two/TwitterProvider.php
+++ b/src/Two/TwitterProvider.php
@@ -12,7 +12,7 @@ class TwitterProvider extends AbstractProvider implements ProviderInterface
      *
      * @var array
      */
-    protected $scopes = ['users.read', 'tweet.read'];
+    protected $scopes = ['users.read', 'tweet.read', 'users.email'];
 
     /**
      * Indicates if PKCE should be used.
@@ -57,8 +57,8 @@ class TwitterProvider extends AbstractProvider implements ProviderInterface
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get('https://api.twitter.com/2/users/me', [
-            RequestOptions::HEADERS => ['Authorization' => 'Bearer '.$token],
-            RequestOptions::QUERY => ['user.fields' => 'profile_image_url'],
+            RequestOptions::HEADERS => ['Authorization' => 'Bearer ' . $token],
+            RequestOptions::QUERY => ['user.fields' => 'profile_image_url,confirmed_email'],
         ]);
 
         return Arr::get(json_decode($response->getBody(), true), 'data');
@@ -74,6 +74,7 @@ class TwitterProvider extends AbstractProvider implements ProviderInterface
             'nickname' => $user['username'],
             'name' => $user['name'],
             'avatar' => $user['profile_image_url'],
+            'email' => $user['confirmed_email'],
         ]);
     }
 

--- a/src/Two/TwitterProvider.php
+++ b/src/Two/TwitterProvider.php
@@ -12,7 +12,7 @@ class TwitterProvider extends AbstractProvider implements ProviderInterface
      *
      * @var array
      */
-    protected $scopes = ['users.read', 'tweet.read', 'users.email'];
+    protected $scopes = ['users.read', 'users.email', 'tweet.read'];
 
     /**
      * Indicates if PKCE should be used.
@@ -71,10 +71,10 @@ class TwitterProvider extends AbstractProvider implements ProviderInterface
     {
         return (new User)->setRaw($user)->map([
             'id' => $user['id'],
+            'email' => $user['confirmed_email'] ?? null,
             'nickname' => $user['username'],
             'name' => $user['name'],
             'avatar' => $user['profile_image_url'],
-            'email' => $user['confirmed_email'],
         ]);
     }
 


### PR DESCRIPTION
Currently, logging in with Twitter (OAuth 2.0) does not return the user's email address.

However, as of April 3rd, X (formerly Twitter) has added support for email retrieval via OAuth 2.0 using the users.email scope and the confirmed_email field.

Official announcement: https://devcommunity.x.com/t/announcing-support-for-email-address-retrieval-with-oauth-2-0-in-the-x-api-v2/240555

This feature is similar in nature to [this Socialite pull request](https://github.com/laravel/socialite/pull/742), which adds support for email in XProvider