### PR TITLE
Fix return type for functions which make use of json_decode

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -362,7 +362,7 @@ abstract class AbstractProvider implements ProviderContract
      * Get the refresh token response for the given refresh token.
      *
      * @param  string  $refreshToken
-     * @return array
+     * @return mixed
      */
     protected function getRefreshTokenResponse($refreshToken)
     {

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -141,7 +141,7 @@ abstract class AbstractProvider implements ProviderContract
      * Get the raw user for the given access token.
      *
      * @param  string  $token
-     * @return array
+     * @return mixed
      */
     abstract protected function getUserByToken($token);
 
@@ -294,7 +294,7 @@ abstract class AbstractProvider implements ProviderContract
      * Get the access token response for the given code.
      *
      * @param  string  $code
-     * @return array
+     * @return mixed
      */
     public function getAccessTokenResponse($code)
     {


### PR DESCRIPTION
json-decode returns with a type of `mixed` not `array` https://www.php.net/manual/de/function.json-decode.php

This causes issues when creating your own SocialiteProvider and making use of phpstan to check types. The return type cannot be set correctly.