### PR TITLE
Improve error handling for invalid access token responses

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -239,7 +239,7 @@ abstract class AbstractProvider implements ProviderContract
 
         $response = $this->getAccessTokenResponse($this->getCode());
 
-        if (! Arr::has($response, 'access_token')) {
+        if (! is_array($response) || ! Arr::has($response, 'access_token')) {
             throw new InvalidTokenResponseException;
         }
 

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -239,6 +239,10 @@ abstract class AbstractProvider implements ProviderContract
 
         $response = $this->getAccessTokenResponse($this->getCode());
 
+        if (! Arr::has($response, 'access_token')) {
+            throw new InvalidTokenResponseException;
+        }
+
         $user = $this->getUserByToken(Arr::get($response, 'access_token'));
 
         return $this->userInstance($response, $user);

--- a/src/Two/InvalidTokenResponseException.php
+++ b/src/Two/InvalidTokenResponseException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Socialite\Two;
+
+use InvalidArgumentException;
+
+class InvalidTokenResponseException extends InvalidArgumentException
+{
+    //
+}

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -11,6 +11,7 @@ use Laravel\Socialite\Tests\Fixtures\GoogleTestProviderStub;
 use Laravel\Socialite\Tests\Fixtures\OAuthTwoTestProviderStub;
 use Laravel\Socialite\Tests\Fixtures\OAuthTwoWithPKCETestProviderStub;
 use Laravel\Socialite\Two\InvalidStateException;
+use Laravel\Socialite\Two\InvalidTokenResponseException;
 use Laravel\Socialite\Two\Token;
 use Laravel\Socialite\Two\User;
 use Mockery as m;
@@ -135,6 +136,22 @@ class OAuthTwoTest extends TestCase
         $this->assertSame('refresh_token', $user->refreshToken);
         $this->assertSame(3600, $user->expiresIn);
         $this->assertSame($user->id, $provider->user()->id);
+    }
+
+    public function testExceptionIsThrownIfAccessTokenIsMissing()
+    {
+        $this->expectException(InvalidTokenResponseException::class);
+
+        $request = Request::create('foo', 'GET', ['state' => str_repeat('A', 40), 'code' => 'code']);
+        $request->setLaravelSession($session = m::mock(Session::class));
+        $session->expects('pull')->with('state')->andReturns(str_repeat('A', 40));
+        $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
+        $provider->http = m::mock(stdClass::class);
+        $provider->http->expects('post')->with('http://token.url', [
+            'headers' => ['Accept' => 'application/json'], 'form_params' => ['grant_type' => 'authorization_code', 'client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
+        ])->andReturns($response = m::mock(stdClass::class));
+        $response->expects('getBody')->andReturns('::invalid_response::');
+        $provider->user();
     }
 
     public function testUserReturnsAUserInstanceForTheAuthenticatedFacebookRequest()


### PR DESCRIPTION
When an OAuth provider's token endpoint returns an invalid response (non-JSON or missing access_token), 
the current code fails with a generic error. This can be confusing when debugging issues, 
especially in cases where firewalls or proxy servers intercept the request and return HTML instead 
(e.g., Cloudflare access denied pages).

This PR adds an `InvalidTokenResponseException` that is thrown, if the OAuth provider's response does not contain the required `access_token`.