### PR TITLE
feat(google): stateless ID token support

### DIFF
--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Socialite\Two;
 
+use Exception;
 use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
 use GuzzleHttp\RequestOptions;
@@ -49,8 +50,9 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     protected function getUserByToken($token)
     {
         if ($this->isJwtToken($token)) {
-            return $this->getUserFromIdToken($token);
+            return $this->getUserFromJwtToken($token);
         }
+
         $response = $this->getHttpClient()->get('https://www.googleapis.com/oauth2/v3/userinfo', [
             RequestOptions::QUERY => [
                 'prettyPrint' => 'false',
@@ -118,31 +120,25 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      *
      * @throws \Exception
      */
-    protected function getUserFromIdToken($idToken)
+    protected function getUserFromJwtToken($idToken)
     {
         try {
-            $jwks = $this->getGoogleJwks();
-            $keys = JWK::parseKeySet($jwks);
+            $user = (array) JWT::decode(
+                $idToken, JWK::parseKeySet($this->getGoogleJwks())
+            );
 
-            $payload = JWT::decode($idToken, $keys);
-
-            $user = (array) $payload;
-            if (
-                ! isset($user['iss']) ||
-                $user['iss'] !== 'https://accounts.google.com'
-            ) {
-                throw new \Exception('Invalid ID token issuer');
+            if (! isset($user['iss']) ||
+                $user['iss'] !== 'https://accounts.google.com') {
+                throw new Exception('Invalid ID token issuer.');
             }
 
             if (! isset($user['aud']) || $user['aud'] !== $this->clientId) {
-                throw new \Exception('Invalid ID token audience');
+                throw new Exception('Invalid ID token audience.');
             }
 
             return $user;
-        } catch (\Exception $e) {
-            throw new \Exception(
-                'Failed to verify Google ID token: '.$e->getMessage()
-            );
+        } catch (Exception $e) {
+            throw new Exception('Failed to verify Google JWT token: '.$e->getMessage());
         }
     }
 

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -48,12 +48,9 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        // Check if token is a JWT (ID token) by looking for JWT structure
         if ($this->isJwtToken($token)) {
             return $this->getUserFromIdToken($token);
         }
-
-        // Handle as access token (existing behavior)
         $response = $this->getHttpClient()->get('https://www.googleapis.com/oauth2/v3/userinfo', [
             RequestOptions::QUERY => [
                 'prettyPrint' => 'false',
@@ -124,17 +121,12 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     protected function getUserFromIdToken($idToken)
     {
         try {
-            // Get Google's public keys and parse them using Firebase JWT's built-in function
             $jwks = $this->getGoogleJwks();
             $keys = JWK::parseKeySet($jwks);
 
-            // Verify and decode the JWT - Firebase JWT automatically selects the correct key
             $payload = JWT::decode($idToken, $keys);
 
-            // Convert to array and validate required claims
             $user = (array) $payload;
-
-            // Verify the token is from Google and for this client
             if (
                 ! isset($user['iss']) ||
                 $user['iss'] !== 'https://accounts.google.com'

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Socialite\Two;
 
+use Firebase\JWT\JWT;
+use Firebase\JWT\JWK;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 
@@ -46,6 +48,12 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
+        // Check if token is a JWT (ID token) by looking for JWT structure
+        if ($this->isJwtToken($token)) {
+            return $this->getUserFromIdToken($token);
+        }
+
+        // Handle as access token (existing behavior)
         $response = $this->getHttpClient()->get('https://www.googleapis.com/oauth2/v3/userinfo', [
             RequestOptions::QUERY => [
                 'prettyPrint' => 'false',
@@ -92,5 +100,70 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
             'avatar' => $avatarUrl = Arr::get($user, 'picture'),
             'avatar_original' => $avatarUrl,
         ]);
+    }
+
+    /**
+     * Determine if the given token is a JWT (ID token).
+     *
+     * @param  string  $token
+     * @return bool
+     */
+    protected function isJwtToken($token)
+    {
+        return substr_count($token, ".") === 2 && strlen($token) > 100;
+    }
+
+    /**
+     * Get user data from Google ID token (JWT).
+     *
+     * @param  string  $idToken
+     * @return array
+     * @throws \Exception
+     */
+    protected function getUserFromIdToken($idToken)
+    {
+        try {
+            // Get Google's public keys and parse them using Firebase JWT's built-in function
+            $jwks = $this->getGoogleJwks();
+            $keys = JWK::parseKeySet($jwks);
+
+            // Verify and decode the JWT - Firebase JWT automatically selects the correct key
+            $payload = JWT::decode($idToken, $keys);
+
+            // Convert to array and validate required claims
+            $user = (array) $payload;
+
+            // Verify the token is from Google and for this client
+            if (
+                !isset($user["iss"]) ||
+                $user["iss"] !== "https://accounts.google.com"
+            ) {
+                throw new \Exception("Invalid ID token issuer");
+            }
+
+            if (!isset($user["aud"]) || $user["aud"] !== $this->clientId) {
+                throw new \Exception("Invalid ID token audience");
+            }
+
+            return $user;
+        } catch (\Exception $e) {
+            throw new \Exception(
+                "Failed to verify Google ID token: " . $e->getMessage()
+            );
+        }
+    }
+
+    /**
+     * Get Google's JSON Web Key Set for JWT verification.
+     *
+     * @return array
+     */
+    protected function getGoogleJwks()
+    {
+        $response = $this->getHttpClient()->get(
+            "https://www.googleapis.com/oauth2/v3/certs"
+        );
+
+        return json_decode((string) $response->getBody(), true);
     }
 }

--- a/src/Two/GoogleProvider.php
+++ b/src/Two/GoogleProvider.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Socialite\Two;
 
-use Firebase\JWT\JWT;
 use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 
@@ -110,7 +110,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      */
     protected function isJwtToken($token)
     {
-        return substr_count($token, ".") === 2 && strlen($token) > 100;
+        return substr_count($token, '.') === 2 && strlen($token) > 100;
     }
 
     /**
@@ -118,6 +118,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
      *
      * @param  string  $idToken
      * @return array
+     *
      * @throws \Exception
      */
     protected function getUserFromIdToken($idToken)
@@ -135,20 +136,20 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
 
             // Verify the token is from Google and for this client
             if (
-                !isset($user["iss"]) ||
-                $user["iss"] !== "https://accounts.google.com"
+                ! isset($user['iss']) ||
+                $user['iss'] !== 'https://accounts.google.com'
             ) {
-                throw new \Exception("Invalid ID token issuer");
+                throw new \Exception('Invalid ID token issuer');
             }
 
-            if (!isset($user["aud"]) || $user["aud"] !== $this->clientId) {
-                throw new \Exception("Invalid ID token audience");
+            if (! isset($user['aud']) || $user['aud'] !== $this->clientId) {
+                throw new \Exception('Invalid ID token audience');
             }
 
             return $user;
         } catch (\Exception $e) {
             throw new \Exception(
-                "Failed to verify Google ID token: " . $e->getMessage()
+                'Failed to verify Google ID token: '.$e->getMessage()
             );
         }
     }
@@ -161,7 +162,7 @@ class GoogleProvider extends AbstractProvider implements ProviderInterface
     protected function getGoogleJwks()
     {
         $response = $this->getHttpClient()->get(
-            "https://www.googleapis.com/oauth2/v3/certs"
+            'https://www.googleapis.com/oauth2/v3/certs'
         );
 
         return json_decode((string) $response->getBody(), true);

--- a/tests/GoogleProviderIdTokenTest.php
+++ b/tests/GoogleProviderIdTokenTest.php
@@ -44,7 +44,7 @@ class GoogleProviderIdTokenTest extends TestCase
         $this->mockJwksResponse($provider);
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageMatches('/Failed to verify Google ID token/');
+        $this->expectExceptionMessageMatches('/Failed to verify Google JWT token/');
 
         $provider->userFromToken($idToken);
     }
@@ -107,7 +107,7 @@ class GoogleProviderIdTokenTest extends TestCase
         if ($expectedException) {
             $this->mockJwksResponse($provider);
             $this->expectException(\Exception::class);
-            $this->expectExceptionMessageMatches('/Failed to verify Google ID token/');
+            $this->expectExceptionMessageMatches('/Failed to verify Google JWT token/');
         }
 
         $provider->userFromToken($invalidToken);

--- a/tests/GoogleProviderIdTokenTest.php
+++ b/tests/GoogleProviderIdTokenTest.php
@@ -25,11 +25,9 @@ class GoogleProviderIdTokenTest extends TestCase
     {
         $provider = $this->getProvider();
 
-        // Test JWT token detection
         $jwtToken = $this->createMockJwtToken();
         $accessToken = 'ya29.a0AfH6SMCxyz123456789';
 
-        // Use reflection to test the protected method
         $reflection = new \ReflectionClass($provider);
         $method = $reflection->getMethod('isJwtToken');
         $method->setAccessible(true);
@@ -45,7 +43,6 @@ class GoogleProviderIdTokenTest extends TestCase
 
         $this->mockJwksResponse($provider);
 
-        // JWT verification should fail with mock data
         $this->expectException(\Exception::class);
         $this->expectExceptionMessageMatches('/Failed to verify Google ID token/');
 
@@ -57,7 +54,6 @@ class GoogleProviderIdTokenTest extends TestCase
         $provider = $this->getProvider();
         $accessToken = 'ya29.a0AfH6SMCxyz123456789';
 
-        // Mock the HTTP client for userinfo API call
         $httpClient = m::mock(Client::class);
         $provider->setHttpClient($httpClient);
 
@@ -159,7 +155,6 @@ class GoogleProviderIdTokenTest extends TestCase
         $this->assertEquals('Test User', $user->getName());
         $this->assertEquals('https://lh3.googleusercontent.com/photo.jpg', $user->getAvatar());
 
-        // Test backward compatibility fields
         $rawUser = $user->getRaw();
         $this->assertEquals('123456789012345678901', $rawUser['id']);
         $this->assertTrue($rawUser['verified_email']);
@@ -257,7 +252,6 @@ class GoogleProviderIdTokenTest extends TestCase
             'exp' => time() + 3600,
         ], $overrides['payload'] ?? []);
 
-        // Remove null values
         $header = array_filter($header, function ($value) {
             return $value !== null;
         });

--- a/tests/GoogleProviderIdTokenTest.php
+++ b/tests/GoogleProviderIdTokenTest.php
@@ -27,11 +27,11 @@ class GoogleProviderIdTokenTest extends TestCase
 
         // Test JWT token detection
         $jwtToken = $this->createMockJwtToken();
-        $accessToken = "ya29.a0AfH6SMCxyz123456789";
+        $accessToken = 'ya29.a0AfH6SMCxyz123456789';
 
         // Use reflection to test the protected method
         $reflection = new \ReflectionClass($provider);
-        $method = $reflection->getMethod("isJwtToken");
+        $method = $reflection->getMethod('isJwtToken');
         $method->setAccessible(true);
 
         $this->assertTrue($method->invoke($provider, $jwtToken));
@@ -47,7 +47,7 @@ class GoogleProviderIdTokenTest extends TestCase
 
         // JWT verification should fail with mock data
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageMatches("/Failed to verify Google ID token/");
+        $this->expectExceptionMessageMatches('/Failed to verify Google ID token/');
 
         $provider->userFromToken($idToken);
     }
@@ -55,7 +55,7 @@ class GoogleProviderIdTokenTest extends TestCase
     public function test_it_falls_back_to_api_call_for_access_tokens()
     {
         $provider = $this->getProvider();
-        $accessToken = "ya29.a0AfH6SMCxyz123456789";
+        $accessToken = 'ya29.a0AfH6SMCxyz123456789';
 
         // Mock the HTTP client for userinfo API call
         $httpClient = m::mock(Client::class);
@@ -65,39 +65,39 @@ class GoogleProviderIdTokenTest extends TestCase
         $stream = m::mock(StreamInterface::class);
 
         $mockUserData = [
-            "sub" => "123456789",
-            "email" => "test@example.com",
-            "name" => "Test User",
-            "picture" => "https://example.com/photo.jpg",
+            'sub' => '123456789',
+            'email' => 'test@example.com',
+            'name' => 'Test User',
+            'picture' => 'https://example.com/photo.jpg',
         ];
 
         $httpClient
-            ->shouldReceive("get")
-            ->with("https://www.googleapis.com/oauth2/v3/userinfo", [
+            ->shouldReceive('get')
+            ->with('https://www.googleapis.com/oauth2/v3/userinfo', [
                 RequestOptions::QUERY => [
-                    "prettyPrint" => "false",
+                    'prettyPrint' => 'false',
                 ],
                 RequestOptions::HEADERS => [
-                    "Accept" => "application/json",
-                    "Authorization" => "Bearer " . $accessToken,
+                    'Accept' => 'application/json',
+                    'Authorization' => 'Bearer '.$accessToken,
                 ],
             ])
             ->once()
             ->andReturn($response);
 
-        $response->shouldReceive("getBody")->once()->andReturn($stream);
+        $response->shouldReceive('getBody')->once()->andReturn($stream);
 
         $stream
-            ->shouldReceive("__toString")
+            ->shouldReceive('__toString')
             ->once()
             ->andReturn(json_encode($mockUserData));
 
         $user = $provider->userFromToken($accessToken);
 
         $this->assertInstanceOf(User::class, $user);
-        $this->assertEquals("123456789", $user->getId());
-        $this->assertEquals("test@example.com", $user->getEmail());
-        $this->assertEquals("Test User", $user->getName());
+        $this->assertEquals('123456789', $user->getId());
+        $this->assertEquals('test@example.com', $user->getEmail());
+        $this->assertEquals('Test User', $user->getName());
     }
 
     /**
@@ -111,7 +111,7 @@ class GoogleProviderIdTokenTest extends TestCase
         if ($expectedException) {
             $this->mockJwksResponse($provider);
             $this->expectException(\Exception::class);
-            $this->expectExceptionMessageMatches("/Failed to verify Google ID token/");
+            $this->expectExceptionMessageMatches('/Failed to verify Google ID token/');
         }
 
         $provider->userFromToken($invalidToken);
@@ -122,15 +122,15 @@ class GoogleProviderIdTokenTest extends TestCase
         return [
             'invalid issuer' => [
                 'Invalid issuer',
-                ['payload' => ['iss' => 'https://invalid-issuer.com']]
+                ['payload' => ['iss' => 'https://invalid-issuer.com']],
             ],
             'invalid audience' => [
                 'Invalid audience',
-                ['payload' => ['aud' => 'wrong-client-id']]
+                ['payload' => ['aud' => 'wrong-client-id']],
             ],
             'missing key id' => [
                 'Missing key ID',
-                ['header' => ['kid' => null]]
+                ['header' => ['kid' => null]],
             ],
         ];
     }
@@ -140,29 +140,29 @@ class GoogleProviderIdTokenTest extends TestCase
         $provider = $this->getProvider();
 
         $idTokenUser = [
-            "sub" => "123456789012345678901",
-            "email" => "testuser@gmail.com",
-            "email_verified" => true,
-            "name" => "Test User",
-            "picture" => "https://lh3.googleusercontent.com/photo.jpg",
+            'sub' => '123456789012345678901',
+            'email' => 'testuser@gmail.com',
+            'email_verified' => true,
+            'name' => 'Test User',
+            'picture' => 'https://lh3.googleusercontent.com/photo.jpg',
         ];
 
         $reflection = new \ReflectionClass($provider);
-        $method = $reflection->getMethod("mapUserToObject");
+        $method = $reflection->getMethod('mapUserToObject');
         $method->setAccessible(true);
 
         $user = $method->invoke($provider, $idTokenUser);
 
         $this->assertInstanceOf(User::class, $user);
-        $this->assertEquals("123456789012345678901", $user->getId());
-        $this->assertEquals("testuser@gmail.com", $user->getEmail());
-        $this->assertEquals("Test User", $user->getName());
-        $this->assertEquals("https://lh3.googleusercontent.com/photo.jpg", $user->getAvatar());
+        $this->assertEquals('123456789012345678901', $user->getId());
+        $this->assertEquals('testuser@gmail.com', $user->getEmail());
+        $this->assertEquals('Test User', $user->getName());
+        $this->assertEquals('https://lh3.googleusercontent.com/photo.jpg', $user->getAvatar());
 
         // Test backward compatibility fields
         $rawUser = $user->getRaw();
-        $this->assertEquals("123456789012345678901", $rawUser["id"]);
-        $this->assertTrue($rawUser["verified_email"]);
+        $this->assertEquals('123456789012345678901', $rawUser['id']);
+        $this->assertTrue($rawUser['verified_email']);
     }
 
     /**
@@ -170,13 +170,13 @@ class GoogleProviderIdTokenTest extends TestCase
      */
     protected function getProvider()
     {
-        $request = Request::create("/");
+        $request = Request::create('/');
 
         return new GoogleProvider(
             $request,
-            "test-client-id",
-            "test-client-secret",
-            "http://localhost/callback"
+            'test-client-id',
+            'test-client-secret',
+            'http://localhost/callback'
         );
     }
 
@@ -185,24 +185,24 @@ class GoogleProviderIdTokenTest extends TestCase
      */
     protected function createMockJwtToken()
     {
-        $header = ["typ" => "JWT", "alg" => "RS256", "kid" => "test-key-id"];
+        $header = ['typ' => 'JWT', 'alg' => 'RS256', 'kid' => 'test-key-id'];
         $payload = [
-            "iss" => "https://accounts.google.com",
-            "sub" => "123456789012345678901",
-            "aud" => "test-client-id",
-            "email" => "testuser@gmail.com",
-            "email_verified" => true,
-            "name" => "Test User",
-            "picture" => "https://lh3.googleusercontent.com/photo.jpg",
-            "iat" => time(),
-            "exp" => time() + 3600,
+            'iss' => 'https://accounts.google.com',
+            'sub' => '123456789012345678901',
+            'aud' => 'test-client-id',
+            'email' => 'testuser@gmail.com',
+            'email_verified' => true,
+            'name' => 'Test User',
+            'picture' => 'https://lh3.googleusercontent.com/photo.jpg',
+            'iat' => time(),
+            'exp' => time() + 3600,
         ];
 
-        return $this->base64UrlEncode(json_encode($header)) .
-            "." .
-            $this->base64UrlEncode(json_encode($payload)) .
-            "." .
-            $this->base64UrlEncode("mock-signature");
+        return $this->base64UrlEncode(json_encode($header)).
+            '.'.
+            $this->base64UrlEncode(json_encode($payload)).
+            '.'.
+            $this->base64UrlEncode('mock-signature');
     }
 
     /**
@@ -217,24 +217,24 @@ class GoogleProviderIdTokenTest extends TestCase
         $jwksStream = m::mock(StreamInterface::class);
 
         $mockJwks = [
-            "keys" => [
+            'keys' => [
                 [
-                    "kid" => "test-key-id",
-                    "kty" => "RSA",
-                    "use" => "sig",
-                    "n" => "mock-n-value",
-                    "e" => "AQAB",
+                    'kid' => 'test-key-id',
+                    'kty' => 'RSA',
+                    'use' => 'sig',
+                    'n' => 'mock-n-value',
+                    'e' => 'AQAB',
                 ],
             ],
         ];
 
-        $httpClient->shouldReceive("get")
-            ->with("https://www.googleapis.com/oauth2/v3/certs")
+        $httpClient->shouldReceive('get')
+            ->with('https://www.googleapis.com/oauth2/v3/certs')
             ->once()
             ->andReturn($jwksResponse);
 
-        $jwksResponse->shouldReceive("getBody")->once()->andReturn($jwksStream);
-        $jwksStream->shouldReceive("__toString")->once()->andReturn(json_encode($mockJwks));
+        $jwksResponse->shouldReceive('getBody')->once()->andReturn($jwksStream);
+        $jwksStream->shouldReceive('__toString')->once()->andReturn(json_encode($mockJwks));
     }
 
     /**
@@ -243,26 +243,28 @@ class GoogleProviderIdTokenTest extends TestCase
     protected function createInvalidJwtToken(array $overrides)
     {
         $header = array_merge(
-            ["typ" => "JWT", "alg" => "RS256", "kid" => "test-key-id"],
+            ['typ' => 'JWT', 'alg' => 'RS256', 'kid' => 'test-key-id'],
             $overrides['header'] ?? []
         );
 
         $payload = array_merge([
-            "iss" => "https://accounts.google.com",
-            "sub" => "123456789",
-            "aud" => "test-client-id",
-            "email" => "test@example.com",
-            "name" => "Test User",
-            "iat" => time(),
-            "exp" => time() + 3600,
+            'iss' => 'https://accounts.google.com',
+            'sub' => '123456789',
+            'aud' => 'test-client-id',
+            'email' => 'test@example.com',
+            'name' => 'Test User',
+            'iat' => time(),
+            'exp' => time() + 3600,
         ], $overrides['payload'] ?? []);
 
         // Remove null values
-        $header = array_filter($header, function($value) { return $value !== null; });
+        $header = array_filter($header, function ($value) {
+            return $value !== null;
+        });
 
-        return $this->base64UrlEncode(json_encode($header)) . "." .
-               $this->base64UrlEncode(json_encode($payload)) . "." .
-               $this->base64UrlEncode("mock-signature");
+        return $this->base64UrlEncode(json_encode($header)).'.'.
+               $this->base64UrlEncode(json_encode($payload)).'.'.
+               $this->base64UrlEncode('mock-signature');
     }
 
     /**
@@ -270,6 +272,6 @@ class GoogleProviderIdTokenTest extends TestCase
      */
     protected function base64UrlEncode($data)
     {
-        return rtrim(strtr(base64_encode($data), "+/", "-_"), "=");
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
     }
 }

--- a/tests/GoogleProviderIdTokenTest.php
+++ b/tests/GoogleProviderIdTokenTest.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace Laravel\Socialite\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use Illuminate\Http\Request;
+use Laravel\Socialite\Two\GoogleProvider;
+use Laravel\Socialite\Two\User;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class GoogleProviderIdTokenTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    public function test_it_can_detect_jwt_tokens()
+    {
+        $provider = $this->getProvider();
+
+        // Test JWT token detection
+        $jwtToken = $this->createMockJwtToken();
+        $accessToken = "ya29.a0AfH6SMCxyz123456789";
+
+        // Use reflection to test the protected method
+        $reflection = new \ReflectionClass($provider);
+        $method = $reflection->getMethod("isJwtToken");
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($provider, $jwtToken));
+        $this->assertFalse($method->invoke($provider, $accessToken));
+    }
+
+    public function test_it_uses_jwt_verification_for_id_tokens()
+    {
+        $provider = $this->getProvider();
+        $idToken = $this->createMockJwtToken();
+
+        $this->mockJwksResponse($provider);
+
+        // JWT verification should fail with mock data
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/Failed to verify Google ID token/");
+
+        $provider->userFromToken($idToken);
+    }
+
+    public function test_it_falls_back_to_api_call_for_access_tokens()
+    {
+        $provider = $this->getProvider();
+        $accessToken = "ya29.a0AfH6SMCxyz123456789";
+
+        // Mock the HTTP client for userinfo API call
+        $httpClient = m::mock(Client::class);
+        $provider->setHttpClient($httpClient);
+
+        $response = m::mock(ResponseInterface::class);
+        $stream = m::mock(StreamInterface::class);
+
+        $mockUserData = [
+            "sub" => "123456789",
+            "email" => "test@example.com",
+            "name" => "Test User",
+            "picture" => "https://example.com/photo.jpg",
+        ];
+
+        $httpClient
+            ->shouldReceive("get")
+            ->with("https://www.googleapis.com/oauth2/v3/userinfo", [
+                RequestOptions::QUERY => [
+                    "prettyPrint" => "false",
+                ],
+                RequestOptions::HEADERS => [
+                    "Accept" => "application/json",
+                    "Authorization" => "Bearer " . $accessToken,
+                ],
+            ])
+            ->once()
+            ->andReturn($response);
+
+        $response->shouldReceive("getBody")->once()->andReturn($stream);
+
+        $stream
+            ->shouldReceive("__toString")
+            ->once()
+            ->andReturn(json_encode($mockUserData));
+
+        $user = $provider->userFromToken($accessToken);
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertEquals("123456789", $user->getId());
+        $this->assertEquals("test@example.com", $user->getEmail());
+        $this->assertEquals("Test User", $user->getName());
+    }
+
+    /**
+     * @dataProvider invalidJwtProvider
+     */
+    public function test_it_handles_invalid_jwt_tokens($description, $tokenOverrides, $expectedException = true)
+    {
+        $provider = $this->getProvider();
+        $invalidToken = $this->createInvalidJwtToken($tokenOverrides);
+
+        if ($expectedException) {
+            $this->mockJwksResponse($provider);
+            $this->expectException(\Exception::class);
+            $this->expectExceptionMessageMatches("/Failed to verify Google ID token/");
+        }
+
+        $provider->userFromToken($invalidToken);
+    }
+
+    public static function invalidJwtProvider()
+    {
+        return [
+            'invalid issuer' => [
+                'Invalid issuer',
+                ['payload' => ['iss' => 'https://invalid-issuer.com']]
+            ],
+            'invalid audience' => [
+                'Invalid audience',
+                ['payload' => ['aud' => 'wrong-client-id']]
+            ],
+            'missing key id' => [
+                'Missing key ID',
+                ['header' => ['kid' => null]]
+            ],
+        ];
+    }
+
+    public function test_user_mapping_works_with_id_token_format()
+    {
+        $provider = $this->getProvider();
+
+        $idTokenUser = [
+            "sub" => "123456789012345678901",
+            "email" => "testuser@gmail.com",
+            "email_verified" => true,
+            "name" => "Test User",
+            "picture" => "https://lh3.googleusercontent.com/photo.jpg",
+        ];
+
+        $reflection = new \ReflectionClass($provider);
+        $method = $reflection->getMethod("mapUserToObject");
+        $method->setAccessible(true);
+
+        $user = $method->invoke($provider, $idTokenUser);
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertEquals("123456789012345678901", $user->getId());
+        $this->assertEquals("testuser@gmail.com", $user->getEmail());
+        $this->assertEquals("Test User", $user->getName());
+        $this->assertEquals("https://lh3.googleusercontent.com/photo.jpg", $user->getAvatar());
+
+        // Test backward compatibility fields
+        $rawUser = $user->getRaw();
+        $this->assertEquals("123456789012345678901", $rawUser["id"]);
+        $this->assertTrue($rawUser["verified_email"]);
+    }
+
+    /**
+     * Get a GoogleProvider instance for testing.
+     */
+    protected function getProvider()
+    {
+        $request = Request::create("/");
+
+        return new GoogleProvider(
+            $request,
+            "test-client-id",
+            "test-client-secret",
+            "http://localhost/callback"
+        );
+    }
+
+    /**
+     * Create a mock JWT token for testing.
+     */
+    protected function createMockJwtToken()
+    {
+        $header = ["typ" => "JWT", "alg" => "RS256", "kid" => "test-key-id"];
+        $payload = [
+            "iss" => "https://accounts.google.com",
+            "sub" => "123456789012345678901",
+            "aud" => "test-client-id",
+            "email" => "testuser@gmail.com",
+            "email_verified" => true,
+            "name" => "Test User",
+            "picture" => "https://lh3.googleusercontent.com/photo.jpg",
+            "iat" => time(),
+            "exp" => time() + 3600,
+        ];
+
+        return $this->base64UrlEncode(json_encode($header)) .
+            "." .
+            $this->base64UrlEncode(json_encode($payload)) .
+            "." .
+            $this->base64UrlEncode("mock-signature");
+    }
+
+    /**
+     * Mock JWKS response for testing JWT verification.
+     */
+    protected function mockJwksResponse($provider)
+    {
+        $httpClient = m::mock(Client::class);
+        $provider->setHttpClient($httpClient);
+
+        $jwksResponse = m::mock(ResponseInterface::class);
+        $jwksStream = m::mock(StreamInterface::class);
+
+        $mockJwks = [
+            "keys" => [
+                [
+                    "kid" => "test-key-id",
+                    "kty" => "RSA",
+                    "use" => "sig",
+                    "n" => "mock-n-value",
+                    "e" => "AQAB",
+                ],
+            ],
+        ];
+
+        $httpClient->shouldReceive("get")
+            ->with("https://www.googleapis.com/oauth2/v3/certs")
+            ->once()
+            ->andReturn($jwksResponse);
+
+        $jwksResponse->shouldReceive("getBody")->once()->andReturn($jwksStream);
+        $jwksStream->shouldReceive("__toString")->once()->andReturn(json_encode($mockJwks));
+    }
+
+    /**
+     * Create an invalid JWT token for testing.
+     */
+    protected function createInvalidJwtToken(array $overrides)
+    {
+        $header = array_merge(
+            ["typ" => "JWT", "alg" => "RS256", "kid" => "test-key-id"],
+            $overrides['header'] ?? []
+        );
+
+        $payload = array_merge([
+            "iss" => "https://accounts.google.com",
+            "sub" => "123456789",
+            "aud" => "test-client-id",
+            "email" => "test@example.com",
+            "name" => "Test User",
+            "iat" => time(),
+            "exp" => time() + 3600,
+        ], $overrides['payload'] ?? []);
+
+        // Remove null values
+        $header = array_filter($header, function($value) { return $value !== null; });
+
+        return $this->base64UrlEncode(json_encode($header)) . "." .
+               $this->base64UrlEncode(json_encode($payload)) . "." .
+               $this->base64UrlEncode("mock-signature");
+    }
+
+    /**
+     * Base64URL encode data.
+     */
+    protected function base64UrlEncode($data)
+    {
+        return rtrim(strtr(base64_encode($data), "+/", "-_"), "=");
+    }
+}


### PR DESCRIPTION
Fixes #726 

- Detect and verify JWT ID tokens
- Use Firebase JWT parseKeySet() for automatic key selection
- Maintain access token fallback

A similar thing has already been implemented in `FacebookProvider`. Feedback welcome :)