### PR TITLE
Update Facebook Graph API version to v23.0

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -24,7 +24,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      *
      * @var string
      */
-    protected $version = 'v3.3';
+    protected $version = 'v23.0';
 
     /**
      * The user fields being requested.

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -144,7 +144,7 @@ class OAuthTwoTest extends TestCase
         $session->expects('pull')->with('state')->andReturns(str_repeat('A', 40));
         $provider = new FacebookTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock(stdClass::class);
-        $provider->http->expects('post')->with('https://graph.facebook.com/v3.3/oauth/access_token', [
+        $provider->http->expects('post')->with('https://graph.facebook.com/v23.0/oauth/access_token', [
             'form_params' => ['grant_type' => 'authorization_code', 'client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
         ])->andReturns($response = m::mock(stdClass::class));
         $response->expects('getBody')->andReturns(json_encode(['access_token' => 'access_token', 'expires' => 5183085]));


### PR DESCRIPTION
<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Facebook Graph API v3.3 was [deprecated on August 3, 2021](https://developers.facebook.com/docs/graph-api/changelog/version3.3/).

Current calls to the API are auto-upgraded to v17.0, as the HTTP header `X-Ad-Api-Version-Warning: The call has been auto-upgraded to v17.0 as v3.3 has been deprecated.`.

Between v17.0 and v23.0, there's no impact on Socialite.

Fixes https://github.com/laravel/socialite/issues/685, https://github.com/laravel/socialite/issues/705, and others.