### PR TITLE
Fix the Facebook avatar URL

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -31,7 +31,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      *
      * @var array
      */
-    protected $fields = ['name', 'email', 'gender', 'verified', 'link'];
+    protected $fields = ['name', 'email', 'gender', 'verified', 'link', 'picture.width(1920)'];
 
     /**
      * The scopes being requested.
@@ -186,19 +186,13 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
      */
     protected function mapUserToObject(array $user)
     {
-        if (! isset($user['sub'])) {
-            $avatarUrl = $this->graphUrl.'/'.$this->version.'/'.$user['id'].'/picture';
-
-            $avatarOriginalUrl = $avatarUrl.'?width=1920';
-        }
-
         return (new User)->setRaw($user)->map([
             'id' => $user['id'],
             'nickname' => null,
             'name' => $user['name'] ?? null,
             'email' => $user['email'] ?? null,
-            'avatar' => $avatarUrl ?? $user['picture'] ?? null,
-            'avatar_original' => $avatarOriginalUrl ?? $user['picture'] ?? null,
+            'avatar' => $avatarUrl = Arr::get($user, 'picture.data.url'),
+            'avatar_original' => $avatarUrl,
             'profileUrl' => $user['link'] ?? null,
         ]);
     }


### PR DESCRIPTION
<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
The current URL of a Facebook avatar is the silhouette image, since the URL to fetch the avatar does not include an access token. Adding `picture.width(1920)` to the field list adds it to the authenticated API call, fixing the issue.

**Do note that "profile picture URLs [...] will expire" [1].**

Relevant documentation:

- [1] https://developers.facebook.com/docs/graph-api/reference/user/picture/

Fixes https://github.com/laravel/socialite/issues/487, https://github.com/laravel/socialite/issues/530, https://github.com/laravel/socialite/issues/601, and others.

---

<details><summary>dump of $user</summary>

Some fields are missing because my app only has the `email` and `personal_profile` (default) permissions.

```
Laravel\Socialite\Two\User {
  +id: "<redacted>"
  +nickname: null
  +name: "<redacted>"
  +email: "<redacted>"
  +avatar: "https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=<redacted>&width=1920&ext=1755864786&hash=<redacted>"
  +user: array:4 [▼
    "name" => "<redacted>"
    "email" => "<redacted>"
    "picture" => array:1 [▼
      "data" => array:4 [▼
        "height" => 1118
        "is_silhouette" => false
        "url" => "https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=<redacted>&width=1920&ext=1755864786&hash=<redacted>"
        "width" => 1118
      ]
    ]
    "id" => "<redacted>"
  ]
  +attributes: array:7 [▼
    "id" => "<redacted>"
    "nickname" => null
    "name" => "<redacted>"
    "email" => "<redacted>"
    "avatar" => "https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=<redacted>&width=1920&ext=1755864786&hash=<redacted>"
    "avatar_original" => "https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=<redacted>&width=1920&ext=1755864786&hash=<redacted>"
    "profileUrl" => null
  ]
  +token: "<redacted>"
  +refreshToken: null
  +expiresIn: 5177398
  +approvedScopes: array:1 [▼
    0 => ""
  ]
}
```

</details> 