### PR TITLE
Add Testing Fakes

### DIFF
--- a/src/Socialite.php
+++ b/src/Socialite.php
@@ -33,7 +33,7 @@ class Socialite extends Facade
      * Register a fake Socialite instance.
      *
      * @param  string  $driver
-     * @param  \Laravel\Socialite\Contracts\User|\Closure|null  $user
+     * @param  \Laravel\Socialite\Contracts\User|\Closure|array|null  $user
      * @return \Laravel\Socialite\Testing\SocialiteFake
      */
     public static function fake(string $driver, $user = null)

--- a/src/Socialite.php
+++ b/src/Socialite.php
@@ -2,11 +2,8 @@
 
 namespace Laravel\Socialite;
 
-use Closure;
 use Illuminate\Support\Facades\Facade;
-use Illuminate\Support\Testing\Fakes\BusFake;
 use Laravel\Socialite\Contracts\Factory;
-use Laravel\Socialite\Contracts\User;
 use Laravel\Socialite\Testing\SocialiteFake;
 
 /**

--- a/src/Socialite.php
+++ b/src/Socialite.php
@@ -2,8 +2,12 @@
 
 namespace Laravel\Socialite;
 
+use Closure;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Testing\Fakes\BusFake;
 use Laravel\Socialite\Contracts\Factory;
+use Laravel\Socialite\Contracts\User;
+use Laravel\Socialite\Testing\SocialiteFake;
 
 /**
  * @method static \Laravel\Socialite\Contracts\Provider driver(string $driver = null)
@@ -26,5 +30,22 @@ class Socialite extends Facade
     protected static function getFacadeAccessor()
     {
         return Factory::class;
+    }
+
+    /**
+     * Register a fake Socialite instance.
+     *
+     * @param  string  $driver
+     * @param  \Laravel\Socialite\Contracts\User|\Closure|null  $user
+     * @param  \Symfony\Component\HttpFoundation\RedirectResponse|\Illuminate\Http\RedirectResponse|null  $redirect
+     * @return \Laravel\Socialite\Testing\SocialiteFake
+     */
+    public static function fake($driver, $user = null, $redirect = null)
+    {
+        $fake = static::isFake()
+            ? static::getFacadeRoot()
+            : tap(new SocialiteFake(static::getFacadeRoot()), fn ($fake) => static::swap($fake));
+
+        return $fake->fake($driver, $user, $redirect);
     }
 }

--- a/src/Socialite.php
+++ b/src/Socialite.php
@@ -34,17 +34,18 @@ class Socialite extends Facade
      *
      * @param  string  $driver
      * @param  \Laravel\Socialite\Contracts\User|\Closure|null  $user
-     * @param  \Symfony\Component\HttpFoundation\RedirectResponse|\Illuminate\Http\RedirectResponse|null  $redirect
      * @return \Laravel\Socialite\Testing\SocialiteFake
      */
-    public static function fake($driver, $user = null, $redirect = null)
+    public static function fake($driver, $user = null)
     {
-        $fake = static::isFake()
-            ? static::getFacadeRoot()
-            : tap(new SocialiteFake(static::getFacadeRoot()), function ($fake) {
-                static::swap($fake);
-            });
+        if (static::isFake()) {
+            $fake = static::getFacadeRoot();
+        } else {
+            $fake = new SocialiteFake(static::getFacadeRoot());
 
-        return $fake->fake($driver, $user, $redirect);
+            static::swap($fake);
+        }
+
+        return $fake->fake($driver, $user);
     }
 }

--- a/src/Socialite.php
+++ b/src/Socialite.php
@@ -36,7 +36,7 @@ class Socialite extends Facade
      * @param  \Laravel\Socialite\Contracts\User|\Closure|null  $user
      * @return \Laravel\Socialite\Testing\SocialiteFake
      */
-    public static function fake($driver, $user = null)
+    public static function fake(string $driver, $user = null)
     {
         $root = static::getFacadeRoot();
 

--- a/src/Socialite.php
+++ b/src/Socialite.php
@@ -41,7 +41,9 @@ class Socialite extends Facade
     {
         $fake = static::isFake()
             ? static::getFacadeRoot()
-            : tap(new SocialiteFake(static::getFacadeRoot()), fn ($fake) => static::swap($fake));
+            : tap(new SocialiteFake(static::getFacadeRoot()), function ($fake) {
+                static::swap($fake);
+            });
 
         return $fake->fake($driver, $user, $redirect);
     }

--- a/src/Socialite.php
+++ b/src/Socialite.php
@@ -38,10 +38,12 @@ class Socialite extends Facade
      */
     public static function fake($driver, $user = null)
     {
-        if (static::isFake()) {
-            $fake = static::getFacadeRoot();
+        $root = static::getFacadeRoot();
+
+        if ($root instanceof SocialiteFake) {
+            $fake = $root;
         } else {
-            $fake = new SocialiteFake(static::getFacadeRoot());
+            $fake = new SocialiteFake($root);
 
             static::swap($fake);
         }

--- a/src/Testing/FakeProvider.php
+++ b/src/Testing/FakeProvider.php
@@ -35,7 +35,7 @@ class FakeProvider implements Provider
     /**
      * The fake user to return.
      *
-     * @var \Laravel\Socialite\Contracts\User|\Closure|null
+     * @var \Laravel\Socialite\Contracts\User|\Closure|array|null
      */
     protected $user = null;
 
@@ -44,7 +44,7 @@ class FakeProvider implements Provider
      *
      * @param  string  $driver
      * @param  \Closure  $resolver
-     * @param  \Laravel\Socialite\Contracts\User|\Closure|null  $user
+     * @param  \Laravel\Socialite\Contracts\User|\Closure|array|null  $user
      */
     public function __construct($driver, $resolver, $user = null)
     {
@@ -95,7 +95,6 @@ class FakeProvider implements Provider
      * Handle calls to methods that are not available on the fake provider.
      *
      * @param  string  $method
-     * @param  array  $parameters
      */
     public function __call($method, array $parameters)
     {

--- a/src/Testing/FakeProvider.php
+++ b/src/Testing/FakeProvider.php
@@ -98,4 +98,3 @@ class FakeProvider implements Provider
         return $this->forwardCallTo($this->provider(), $method, $parameters);
     }
 }
-

--- a/src/Testing/FakeProvider.php
+++ b/src/Testing/FakeProvider.php
@@ -84,7 +84,11 @@ class FakeProvider implements Provider
      */
     public function provider()
     {
-        return $this->provider ??= ($this->resolver)();
+        if (isset($this->provider)) {
+            return $this->provider;
+        }
+
+        return $this->provider = ($this->resolver)();
     }
 
     /**

--- a/src/Testing/FakeProvider.php
+++ b/src/Testing/FakeProvider.php
@@ -92,8 +92,6 @@ class FakeProvider implements Provider
      *
      * @param  string  $method
      * @param  array  $parameters
-     *
-     * @throws \Laravel\Socialite\Testing\FakeProviderMethodNotSupportedException
      */
     public function __call($method, array $parameters)
     {

--- a/src/Testing/FakeProvider.php
+++ b/src/Testing/FakeProvider.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Laravel\Socialite\Testing;
+
+use Closure;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Traits\ForwardsCalls;
+use Laravel\Socialite\Contracts\Provider;
+
+class FakeProvider implements Provider
+{
+    use ForwardsCalls;
+
+    /**
+     * The driver name.
+     *
+     * @var string
+     */
+    protected $driver;
+
+    /**
+     * The provider resolver.
+     *
+     * @var \Closure
+     */
+    protected $resolver;
+
+    /**
+     * The original provider instance.
+     *
+     * @var \Laravel\Socialite\Contracts\Provider
+     */
+    protected $provider;
+
+    /**
+     * The fake user to return.
+     *
+     * @var \Laravel\Socialite\Contracts\User|\Closure|null
+     */
+    protected $user = null;
+
+    /**
+     * Create a new fake provider instance.
+     *
+     * @param  string  $driver
+     * @param  \Closure  $resolver
+     * @param  \Laravel\Socialite\Contracts\User|\Closure|null  $user
+     */
+    public function __construct($driver, $resolver, $user = null)
+    {
+        $this->driver = $driver;
+        $this->resolver = $resolver;
+        $this->user = $user;
+    }
+
+    /**
+     * Redirect the user to the authentication page for the provider.
+     *
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Illuminate\Http\RedirectResponse
+     */
+    public function redirect()
+    {
+        return new RedirectResponse('https://socialite.fake/'.$this->driver.'/authorize');
+    }
+
+    /**
+     * Get the User instance for the authenticated user.
+     *
+     * @return \Laravel\Socialite\Contracts\User
+     */
+    public function user()
+    {
+        if ($this->user instanceof Closure) {
+            return ($this->user)();
+        }
+
+        return $this->user ?? $this->provider()->user();
+    }
+
+    /**
+     * Get the original provider instance.
+     *
+     * @return \Laravel\Socialite\Contracts\Provider
+     */
+    public function provider()
+    {
+        return $this->provider ??= ($this->resolver)();
+    }
+
+    /**
+     * Handle calls to methods that are not available on the fake provider.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     *
+     * @throws \Laravel\Socialite\Testing\FakeProviderMethodNotSupportedException
+     */
+    public function __call($method, array $parameters)
+    {
+        return $this->forwardCallTo($this->provider(), $method, $parameters);
+    }
+}
+

--- a/src/Testing/SocialiteFake.php
+++ b/src/Testing/SocialiteFake.php
@@ -14,13 +14,6 @@ class SocialiteFake implements Factory
     protected $factory;
 
     /**
-     * The fake user to return for each driver.
-     *
-     * @var array<string, \Laravel\Socialite\Contracts\User|\Closure>
-     */
-    protected $users = [];
-
-    /**
      * The fake provider instances.
      *
      * @var array<string, \Laravel\Socialite\Testing\FakeProvider>

--- a/src/Testing/SocialiteFake.php
+++ b/src/Testing/SocialiteFake.php
@@ -19,14 +19,14 @@ class SocialiteFake implements Factory, Fake
      *
      * @var array<string, \Laravel\Socialite\Contracts\User|\Closure>
      */
-    protected array $users = [];
+    protected $users = [];
 
     /**
      * The fake provider instances.
      *
      * @var array<string, \Laravel\Socialite\Testing\FakeProvider>
      */
-    protected array $providers = [];
+    protected $providers = [];
 
     /**
      * Create a new Socialite fake instance.
@@ -58,7 +58,9 @@ class SocialiteFake implements Factory, Fake
      */
     public function fake($driver, $user = null)
     {
-        $resolver = fn () => $this->factory->driver($driver);
+        $resolver = function () use ($driver) {
+            return $this->factory->driver($driver);
+        };
 
         $this->providers[$driver] = new FakeProvider($driver, $resolver, $user);
 

--- a/src/Testing/SocialiteFake.php
+++ b/src/Testing/SocialiteFake.php
@@ -45,7 +45,7 @@ class SocialiteFake implements Factory
      * Register a fake user for the given driver.
      *
      * @param  string  $driver
-     * @param  \Laravel\Socialite\Contracts\User|\Closure|null  $user
+     * @param  \Laravel\Socialite\Contracts\User|\Closure|array|null  $user
      * @return $this
      */
     public function fake($driver, $user = null)

--- a/src/Testing/SocialiteFake.php
+++ b/src/Testing/SocialiteFake.php
@@ -2,10 +2,9 @@
 
 namespace Laravel\Socialite\Testing;
 
-use Illuminate\Support\Testing\Fakes\Fake;
 use Laravel\Socialite\Contracts\Factory;
 
-class SocialiteFake implements Factory, Fake
+class SocialiteFake implements Factory
 {
     /**
      * The original factory instance.

--- a/src/Testing/SocialiteFake.php
+++ b/src/Testing/SocialiteFake.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Laravel\Socialite\Testing;
+
+use Closure;
+use Illuminate\Support\Testing\Fakes\Fake;
+use InvalidArgumentException;
+use Laravel\Socialite\Contracts\Factory;
+use Laravel\Socialite\Contracts\Provider;
+use Laravel\Socialite\Contracts\User;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class SocialiteFake implements Factory, Fake
+{
+    /**
+     * The original factory instance.
+     *
+     * @var \Laravel\Socialite\Contracts\Factory
+     */
+    protected $factory;
+
+    /**
+     * The fake user to return for each driver.
+     *
+     * @var array<string, \Laravel\Socialite\Contracts\User|\Closure>
+     */
+    protected array $users = [];
+
+    /**
+     * The fake provider instances.
+     *
+     * @var array<string, \Laravel\Socialite\Testing\FakeProvider>
+     */
+    protected array $providers = [];
+
+    /**
+     * Create a new Socialite fake instance.
+     *
+     * @param  \Laravel\Socialite\Contracts\Factory  $factory
+     */
+    public function __construct($factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /**
+     * Get an OAuth provider implementation.
+     *
+     * @param  string  $driver
+     * @return \Laravel\Socialite\Contracts\Provider
+     */
+    public function driver($driver = null)
+    {
+        return $this->providers[$driver] ?? $this->factory->driver($driver);
+    }
+
+    /**
+     * Register a fake user for the given driver.
+     *
+     * @param  string  $driver
+     * @param  \Laravel\Socialite\Contracts\User|\Closure|null  $user
+     * @return $this
+     */
+    public function fake($driver, $user = null)
+    {
+        $resolver = fn () => $this->factory->driver($driver);
+
+        $this->providers[$driver] = new FakeProvider($driver, $resolver, $user);
+
+        return $this;
+    }
+}
+

--- a/src/Testing/SocialiteFake.php
+++ b/src/Testing/SocialiteFake.php
@@ -65,4 +65,3 @@ class SocialiteFake implements Factory, Fake
         return $this;
     }
 }
-

--- a/src/Testing/SocialiteFake.php
+++ b/src/Testing/SocialiteFake.php
@@ -2,13 +2,8 @@
 
 namespace Laravel\Socialite\Testing;
 
-use Closure;
 use Illuminate\Support\Testing\Fakes\Fake;
-use InvalidArgumentException;
 use Laravel\Socialite\Contracts\Factory;
-use Laravel\Socialite\Contracts\Provider;
-use Laravel\Socialite\Contracts\User;
-use PHPUnit\Framework\Assert as PHPUnit;
 
 class SocialiteFake implements Factory, Fake
 {

--- a/tests/SocialiteFakeTest.php
+++ b/tests/SocialiteFakeTest.php
@@ -127,4 +127,3 @@ class SocialiteFakeTest extends TestCase
         $this->assertInstanceOf(GoogleProvider::class, Socialite::driver('google'));
     }
 }
-

--- a/tests/SocialiteFakeTest.php
+++ b/tests/SocialiteFakeTest.php
@@ -3,16 +3,13 @@
 namespace Laravel\Socialite\Tests;
 
 use Laravel\Socialite\Contracts\Factory;
-use Laravel\Socialite\Contracts\User;
 use Laravel\Socialite\Socialite;
 use Laravel\Socialite\SocialiteServiceProvider;
 use Laravel\Socialite\Testing\FakeProvider;
 use Laravel\Socialite\Testing\SocialiteFake;
-use Laravel\Socialite\Two\GithubProvider;
 use Laravel\Socialite\Two\GoogleProvider;
 use Laravel\Socialite\Two\User as OAuth2User;
 use Orchestra\Testbench\TestCase;
-use PHPUnit\Framework\AssertionFailedError;
 
 class SocialiteFakeTest extends TestCase
 {

--- a/tests/SocialiteFakeTest.php
+++ b/tests/SocialiteFakeTest.php
@@ -92,7 +92,7 @@ class SocialiteFakeTest extends TestCase
 
         $provider = Socialite::driver('github');
 
-        // These methods are forwarded to the real provider
+        // Verify that methods are forwarded to the real provider
         $provider->stateless();
         $provider->scopes(['user', 'repo']);
         $provider->setScopes(['user:email']);

--- a/tests/SocialiteFakeTest.php
+++ b/tests/SocialiteFakeTest.php
@@ -47,11 +47,13 @@ class SocialiteFakeTest extends TestCase
 
     public function test_it_can_fake_a_driver_with_a_closure()
     {
-        Socialite::fake('github', fn () => (new OAuth2User)->map([
-            'id' => '456',
-            'name' => 'Closure User',
-            'email' => 'closure@example.com',
-        ]));
+        Socialite::fake('github', function () {
+            return (new OAuth2User)->map([
+                'id' => '456',
+                'name' => 'Closure User',
+                'email' => 'closure@example.com',
+            ]);
+        });
 
         $user = Socialite::driver('github')->user();
 

--- a/tests/SocialiteFakeTest.php
+++ b/tests/SocialiteFakeTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Laravel\Socialite\Tests;
+
+use Laravel\Socialite\Contracts\Factory;
+use Laravel\Socialite\Contracts\User;
+use Laravel\Socialite\Socialite;
+use Laravel\Socialite\SocialiteServiceProvider;
+use Laravel\Socialite\Testing\FakeProvider;
+use Laravel\Socialite\Testing\SocialiteFake;
+use Laravel\Socialite\Two\GithubProvider;
+use Laravel\Socialite\Two\GoogleProvider;
+use Laravel\Socialite\Two\User as OAuth2User;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\AssertionFailedError;
+
+class SocialiteFakeTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [SocialiteServiceProvider::class];
+    }
+
+    protected function tearDown(): void
+    {
+        Socialite::clearResolvedInstances();
+
+        parent::tearDown();
+    }
+
+    public function test_it_can_fake_a_driver_with_a_user()
+    {
+        $user = (new OAuth2User)->map([
+            'id' => '123',
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+        ]);
+
+        Socialite::fake('github', $user);
+
+        $this->assertInstanceOf(SocialiteFake::class, $this->app->make(Factory::class));
+        $this->assertInstanceOf(FakeProvider::class, Socialite::driver('github'));
+
+        $retrievedUser = Socialite::driver('github')->user();
+
+        $this->assertSame('123', $retrievedUser->getId());
+        $this->assertSame('Test User', $retrievedUser->getName());
+        $this->assertSame('test@example.com', $retrievedUser->getEmail());
+    }
+
+    public function test_it_can_fake_a_driver_with_a_closure()
+    {
+        Socialite::fake('github', fn () => (new OAuth2User)->map([
+            'id' => '456',
+            'name' => 'Closure User',
+            'email' => 'closure@example.com',
+        ]));
+
+        $user = Socialite::driver('github')->user();
+
+        $this->assertSame('456', $user->getId());
+        $this->assertSame('Closure User', $user->getName());
+    }
+
+    public function test_it_can_fake_multiple_drivers()
+    {
+        Socialite::fake('github', (new OAuth2User)->map(['id' => 'github-123']));
+        Socialite::fake('google', (new OAuth2User)->map(['id' => 'google-456']));
+
+        $this->assertSame('github-123', Socialite::driver('github')->user()->getId());
+        $this->assertSame('google-456', Socialite::driver('google')->user()->getId());
+    }
+
+    public function test_it_returns_fake_redirect_response()
+    {
+        Socialite::fake('github', (new OAuth2User)->map(['id' => '123']));
+
+        $response = Socialite::driver('github')->redirect();
+
+        $this->assertSame('https://socialite.fake/github/authorize', $response->getTargetUrl());
+    }
+
+    public function test_it_forwards_calls_to_the_real_provider_methods()
+    {
+        $this->app['config']->set('services.github', [
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+            'redirect' => 'http://localhost/callback',
+        ]);
+
+        Socialite::fake('github', (new OAuth2User)->map(['id' => '123']));
+
+        $provider = Socialite::driver('github');
+
+        // These methods are forwarded to the real provider
+        $provider->stateless();
+        $provider->scopes(['user', 'repo']);
+        $provider->setScopes(['user:email']);
+        $provider->redirectUrl('http://example.com/callback');
+        $provider->with(['custom' => 'param']);
+        $provider->enablePKCE();
+
+        // Verify that the fake user is returned despite calling other methods
+        $user = $provider->user();
+
+        $this->assertSame('123', $user->getId());
+    }
+
+    public function test_it_returns_real_driver_when_not_faked()
+    {
+        $this->app['config']->set('services.github', [
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+            'redirect' => 'http://localhost/callback',
+        ]);
+
+        $this->app['config']->set('services.google', [
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+            'redirect' => 'http://localhost/callback',
+        ]);
+
+        // Fake only github
+        Socialite::fake('github', (new OAuth2User)->map(['id' => '123']));
+
+        // Github should return the fake provider
+        $this->assertInstanceOf(FakeProvider::class, Socialite::driver('github'));
+
+        // Google should return the real provider since it wasn't faked
+        $this->assertInstanceOf(GoogleProvider::class, Socialite::driver('google'));
+    }
+}
+


### PR DESCRIPTION
### Description

This PR introduces a testing `Fake` system, making it easy to test OAuth authentication flows without hitting real OAuth providers, and without having to use `Mockery`.

### Usage

Consider the Socialite controller below:

```php
class SocialiteController extends Controller
{
    public function redirect(string $provider)
    {
        return Socialite::driver($provider)->redirect();
    }

    public function callback(string $provider)
    {
        $socialiteUser = Socialite::driver($provider)->user();

        $user = User::firstOrCreate(
            ['email' => $socialiteUser->getEmail()],
            [
                'name' => $socialiteUser->getName(),
                "{$provider}_id" => $socialiteUser->getId(),
            ]
        );

        Auth::login($user);

        return redirect('/dashboard');
    }
}
```

Then, in our tests, we can utilize `Socialite::fake($provider, $user)` to initialize the fake and perform assertions:

```php
use Laravel\Socialite\Socialite;
use Laravel\Socialite\Two\User;

test('user is redirected to github', function () {
    Socialite::fake('github');

    get('/auth/github/redirect')->assertRedirect('https://socialite.fake/github/authorize');
});

test('user can login with github', function () {
    $user = (new User)->map([
        'id' => 'github-123',
        'name' => 'John Doe',
        'email' => 'john@example.com',
    ]);

    Socialite::fake('github', $fakeUser);

    get('/auth/github/callback')->assertRedirect('/dashboard');
    
    assertDatabaseHas(User::class, [
        'email' => $user->getEmail(),
        'name' => $user->getName(),
        'github_id' => $user->getId(),
    ]);
});
```

Let me know your thoughts!
