### PR TITLE
Remove redundant `email` mapping causing error for unconfirmed X accounts

### DIFF
--- a/src/Two/XProvider.php
+++ b/src/Two/XProvider.php
@@ -35,16 +35,4 @@ class XProvider extends TwitterProvider
 
         return Arr::get(json_decode($response->getBody(), true), 'data');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function mapUserToObject(array $user)
-    {
-        $user = parent::mapUserToObject($user);
-
-        $user->email = $user['confirmed_email'];
-
-        return $user;
-    }
 }


### PR DESCRIPTION
The `confirmed_email` field assignment throws errors for new accounts without confirmed emails.
`email` is already mapped in [`TwitterProvider`](https://github.com/laravel/socialite/blob/dc13768b9fcbd879f2dbe47623c9c1d5cc9e24ff/src/Two/TwitterProvider.php#L74), hence the `mapUserToObject` not necessary.

<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
