### PR TITLE
 Fix FakeProvider to preserve decorator pattern when forwarding calls

### DIFF
--- a/src/Testing/FakeProvider.php
+++ b/src/Testing/FakeProvider.php
@@ -98,6 +98,6 @@ class FakeProvider implements Provider
      */
     public function __call($method, array $parameters)
     {
-        return $this->forwardCallTo($this->provider(), $method, $parameters);
+        return $this->forwardDecoratedCallTo($this->provider(), $method, $parameters);
     }
 }

--- a/tests/SocialiteFakeTest.php
+++ b/tests/SocialiteFakeTest.php
@@ -105,6 +105,33 @@ class SocialiteFakeTest extends TestCase
         $this->assertSame('123', $user->getId());
     }
 
+    public function test_it_preserves_decorator_pattern_when_chaining_methods()
+    {
+        $this->app['config']->set('services.github', [
+            'client_id' => 'test-client-id',
+            'client_secret' => 'test-client-secret',
+            'redirect' => 'http://localhost/callback',
+        ]);
+
+        Socialite::fake('github', (new OAuth2User)->map(['id' => '123']));
+
+        $provider = Socialite::driver('github');
+        $this->assertInstanceOf(FakeProvider::class, $provider);
+
+        $chainedProvider = $provider->stateless()
+            ->scopes(['user', 'repo'])
+            ->setScopes(['user:email'])
+            ->redirectUrl('http://example.com/callback')
+            ->with(['custom' => 'param'])
+            ->enablePKCE();
+
+        $this->assertInstanceOf(FakeProvider::class, $chainedProvider, 'FakeProvider should be returned, not the real provider');
+        $this->assertSame($provider, $chainedProvider);
+
+        $user = $chainedProvider->user();
+        $this->assertSame('123', $user->getId());
+    }
+
     public function test_it_returns_real_driver_when_not_faked()
     {
         $this->app['config']->set('services.github', [


### PR DESCRIPTION
## Problem:

When using Socialite's fake provider with method chaining, the fake provider incorrectly returns the original driver instance instead of maintaining the fake wrapper.

### Example of bug:

```php
Socialite::fake('google');
$driver = Socialite::driver('google')->stateless();
// Expected: FakeProvider instance
// Actual: Original Google provider instance
```

### Root Cause:

`FakeProvider::__call()` uses `forwardCallTo()` which simply returns the result of the method call on the original provider. Many provider methods return `$this`, so the caller receives the original provider instead of the decorated FakeProvider instance.

### Solution:
Replace `forwardCallTo()` with `forwardDecoratedCallTo()`. The forwardDecoratedCallTo() method checks if the forwarded call returns the same object that was called, and if so, returns $this (the decorator) instead. This preserves the decorator pattern.

### Impact:
- Fixes method chaining with fake providers
- Maintains backward compatibility for methods that don't return $this
- Consistent with Laravel's decorator pattern usage throughout the framework