### PR TITLE
Remove redundant "When to Apply" section from skill body

### DIFF
--- a/resources/boost/skills/socialite-development/SKILL.md
+++ b/resources/boost/skills/socialite-development/SKILL.md
@@ -8,17 +8,6 @@ metadata:
 
 # Socialite Authentication
 
-## When to Apply
-
-Activate this skill when:
-
-- Adding or configuring social login providers
-- Setting up OAuth redirect/callback routes
-- Retrieving or mapping authenticated user details
-- Customizing scopes, parameters, or stateless auth
-- Setting up community providers
-- Testing OAuth flows with Socialite fakes
-
 ## Documentation
 
 Use `search-docs` for detailed Socialite patterns and documentation (installation, configuration, routing, callbacks, testing, scopes, stateless auth).


### PR DESCRIPTION
## Summary

- Removes the `## When to Apply` section from the Socialite skill file
- This section was already fully covered by the skill's `description` frontmatter — removing it doesn't affect skill triggering behavior

See laravel/boost#669 for the corresponding change in the Boost monorepo.