### PR TITLE
Make redirect config key optional when using redirectUrl()

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -239,7 +239,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     public function buildProvider($provider, $config)
     {
-        $requiredKeys = ['client_id', 'client_secret', 'redirect'];
+        $requiredKeys = ['client_id', 'client_secret'];
 
         $missingKeys = array_diff($requiredKeys, array_keys($config ?? []));
 
@@ -277,7 +277,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function formatRedirectUrl(array $config)
     {
-        $redirect = value($config['redirect']);
+        $redirect = value($config['redirect'] ?? null);
 
         return Str::startsWith($redirect ?? '', '/')
                     ? $this->container->make('url')->to($redirect)

--- a/tests/SocialiteManagerTest.php
+++ b/tests/SocialiteManagerTest.php
@@ -109,11 +109,8 @@ class SocialiteManagerTest extends TestCase
         $factory->driver('github');
     }
 
-    public function test_it_throws_exception_when_redirect_is_missing()
+    public function test_it_can_instantiate_driver_without_redirect_config_key()
     {
-        $this->expectException(DriverMissingConfigurationException::class);
-        $this->expectExceptionMessage('Missing required configuration keys [redirect] for [Laravel\Socialite\Two\GithubProvider] OAuth provider.');
-
         $factory = $this->app->make(Factory::class);
 
         $this->app['config']->set('services.github', [
@@ -121,13 +118,15 @@ class SocialiteManagerTest extends TestCase
             'client_secret' => 'github-client-secret',
         ]);
 
-        $factory->driver('github');
+        $provider = $factory->driver('github');
+
+        $this->assertInstanceOf(GithubProvider::class, $provider);
     }
 
     public function test_it_throws_exception_when_configuration_is_completely_missing()
     {
         $this->expectException(DriverMissingConfigurationException::class);
-        $this->expectExceptionMessage('Missing required configuration keys [client_id, client_secret, redirect] for [Laravel\Socialite\Two\GithubProvider] OAuth provider.');
+        $this->expectExceptionMessage('Missing required configuration keys [client_id, client_secret] for [Laravel\Socialite\Two\GithubProvider] OAuth provider.');
 
         $factory = $this->app->make(Factory::class);
 


### PR DESCRIPTION
## Summary
- Removes `redirect` from the required config keys in `buildProvider()`, allowing users to set the redirect URL programmatically via `redirectUrl()` without needing an empty `redirect` key in `config/services.php`
- Handles missing `redirect` key gracefully in `formatRedirectUrl()` by defaulting to null

Fixes #740

## Test plan
- [x] Updated test: driver can be instantiated without `redirect` config key
- [x] Updated test: exception message for completely missing config reflects new required keys
- [x] All non-JWT tests pass (JWT failures are pre-existing due to missing firebase/php-jwt dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)