### PR TITLE
Use hash_equals for constant-time state comparison

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -287,7 +287,7 @@ abstract class AbstractProvider implements ProviderContract
 
         $state = $this->request->session()->pull('state');
 
-        return empty($state) || $this->request->input('state') !== $state;
+        return empty($state) || ! hash_equals($state, (string) $this->request->input('state'));
     }
 
     /**


### PR DESCRIPTION
The OAuth2 state parameter is compared using `!==`, which is not constant-time. This replaces it with `hash_equals()` to prevent timing side-channel leakage during state validation.
