### PR TITLE
Fix usage of access_token in Bitbucket integration

### DIFF
--- a/src/Two/BitbucketProvider.php
+++ b/src/Two/BitbucketProvider.php
@@ -44,7 +44,9 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get('https://api.bitbucket.org/2.0/user', [
-            RequestOptions::QUERY => ['access_token' => $token],
+            RequestOptions::HEADERS => [
+                'Authorization' => 'Bearer '.$token,
+            ],
         ]);
 
         $user = json_decode($response->getBody(), true);
@@ -64,10 +66,14 @@ class BitbucketProvider extends AbstractProvider implements ProviderInterface
      */
     protected function getEmailByToken($token)
     {
-        $emailsUrl = 'https://api.bitbucket.org/2.0/user/emails?access_token='.$token;
+        $emailsUrl = 'https://api.bitbucket.org/2.0/user/emails';
 
         try {
-            $response = $this->getHttpClient()->get($emailsUrl);
+            $response = $this->getHttpClient()->get($emailsUrl, [
+                RequestOptions::HEADERS => [
+                    'Authorization' => 'Bearer '.$token,
+                ],
+            ]);
         } catch (Exception $e) {
             return;
         }


### PR DESCRIPTION
The Bitbucket integration is currently failing because they deprecated sending access tokens via GET or POST parameters. Instead the access token needs to be sent as a Bearer Token.

See https://developer.atlassian.com/cloud/bitbucket/changelog/#OAuth-access-tokens-can-no-longer-be-provided-via-query-parameters-or-POST-body for more details.

This PR replaces the query parameter `access_token` with the Bearer token for user and e-mail retrieval.