### PR TITLE
[5.x] Add ability to easily fake Socialite users

### DIFF
--- a/src/One/User.php
+++ b/src/One/User.php
@@ -24,7 +24,7 @@ class User extends AbstractUser
      * Create a fake OAuth 1 user instance.
      *
      * @param  array  $attributes
-     * @return static
+     * @return self
      */
     public static function fake(array $attributes = [])
     {
@@ -38,7 +38,7 @@ class User extends AbstractUser
             'tokenSecret' => 'fake-token-secret',
         ], $attributes);
 
-        return (new static)->setRaw($attributes)->map($attributes)
+        return (new self)->setRaw($attributes)->map($attributes)
             ->setToken($attributes['token'], $attributes['tokenSecret']);
     }
 

--- a/src/One/User.php
+++ b/src/One/User.php
@@ -21,6 +21,28 @@ class User extends AbstractUser
     public $tokenSecret;
 
     /**
+     * Create a fake OAuth 1 user instance.
+     *
+     * @param  array  $attributes
+     * @return static
+     */
+    public static function fake(array $attributes = [])
+    {
+        $attributes = array_merge([
+            'id' => '123456789',
+            'nickname' => 'testuser',
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'avatar' => 'https://example.com/avatar.jpg',
+            'token' => 'fake-token',
+            'tokenSecret' => 'fake-token-secret',
+        ], $attributes);
+
+        return (new static)->setRaw($attributes)->map($attributes)
+            ->setToken($attributes['token'], $attributes['tokenSecret']);
+    }
+
+    /**
      * Set the token on the user.
      *
      * @param  string  $token

--- a/src/Socialite.php
+++ b/src/Socialite.php
@@ -33,7 +33,7 @@ class Socialite extends Facade
      * Register a fake Socialite instance.
      *
      * @param  string  $driver
-     * @param  \Laravel\Socialite\Contracts\User|\Closure|array|null  $user
+     * @param  \Laravel\Socialite\Contracts\User|\Closure|null  $user
      * @return \Laravel\Socialite\Testing\SocialiteFake
      */
     public static function fake(string $driver, $user = null)

--- a/src/Testing/FakeProvider.php
+++ b/src/Testing/FakeProvider.php
@@ -35,7 +35,7 @@ class FakeProvider implements Provider
     /**
      * The fake user to return.
      *
-     * @var \Laravel\Socialite\Contracts\User|\Closure|array|null
+     * @var \Laravel\Socialite\Contracts\User|\Closure|null
      */
     protected $user = null;
 
@@ -44,7 +44,7 @@ class FakeProvider implements Provider
      *
      * @param  string  $driver
      * @param  \Closure  $resolver
-     * @param  \Laravel\Socialite\Contracts\User|\Closure|array|null  $user
+     * @param  \Laravel\Socialite\Contracts\User|\Closure|null  $user
      */
     public function __construct($driver, $resolver, $user = null)
     {

--- a/src/Testing/SocialiteFake.php
+++ b/src/Testing/SocialiteFake.php
@@ -45,7 +45,7 @@ class SocialiteFake implements Factory
      * Register a fake user for the given driver.
      *
      * @param  string  $driver
-     * @param  \Laravel\Socialite\Contracts\User|\Closure|array|null  $user
+     * @param  \Laravel\Socialite\Contracts\User|\Closure|null  $user
      * @return $this
      */
     public function fake($driver, $user = null)

--- a/src/Two/User.php
+++ b/src/Two/User.php
@@ -38,7 +38,7 @@ class User extends AbstractUser
      * Create a fake OAuth 2 user instance.
      *
      * @param  array  $attributes
-     * @return static
+     * @return self
      */
     public static function fake(array $attributes = [])
     {
@@ -54,7 +54,7 @@ class User extends AbstractUser
             'approvedScopes' => [],
         ], $attributes);
 
-        return (new static)->setRaw($attributes)->map($attributes)
+        return (new self)->setRaw($attributes)->map($attributes)
             ->setToken($attributes['token'])
             ->setRefreshToken($attributes['refreshToken'])
             ->setExpiresIn($attributes['expiresIn'])

--- a/src/Two/User.php
+++ b/src/Two/User.php
@@ -35,6 +35,33 @@ class User extends AbstractUser
     public $approvedScopes;
 
     /**
+     * Create a fake OAuth 2 user instance.
+     *
+     * @param  array  $attributes
+     * @return static
+     */
+    public static function fake(array $attributes = [])
+    {
+        $attributes = array_merge([
+            'id' => '123456789',
+            'nickname' => 'testuser',
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'avatar' => 'https://example.com/avatar.jpg',
+            'token' => 'fake-token',
+            'refreshToken' => 'fake-refresh-token',
+            'expiresIn' => 3600,
+            'approvedScopes' => [],
+        ], $attributes);
+
+        return (new static)->setRaw($attributes)->map($attributes)
+            ->setToken($attributes['token'])
+            ->setRefreshToken($attributes['refreshToken'])
+            ->setExpiresIn($attributes['expiresIn'])
+            ->setApprovedScopes($attributes['approvedScopes']);
+    }
+
+    /**
      * Set the token on the user.
      *
      * @param  string  $token

--- a/tests/SocialiteFakeTest.php
+++ b/tests/SocialiteFakeTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Socialite\Tests;
 
 use Laravel\Socialite\Contracts\Factory;
+use Laravel\Socialite\One\User as OAuth1User;
 use Laravel\Socialite\Socialite;
 use Laravel\Socialite\SocialiteServiceProvider;
 use Laravel\Socialite\Testing\FakeProvider;
@@ -43,6 +44,106 @@ class SocialiteFakeTest extends TestCase
         $this->assertSame('123', $retrievedUser->getId());
         $this->assertSame('Test User', $retrievedUser->getName());
         $this->assertSame('test@example.com', $retrievedUser->getEmail());
+    }
+
+    public function test_it_can_fake_a_driver_with_a_fake_user()
+    {
+        Socialite::fake('github', OAuth2User::fake([
+            'id' => '123',
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+        ]));
+
+        $user = Socialite::driver('github')->user();
+
+        $this->assertSame('123', $user->getId());
+        $this->assertSame('Test User', $user->getName());
+        $this->assertSame('test@example.com', $user->getEmail());
+        $this->assertSame('fake-token', $user->token);
+    }
+
+    public function test_it_can_create_a_fake_oauth2_user()
+    {
+        $user = OAuth2User::fake();
+
+        $this->assertInstanceOf(OAuth2User::class, $user);
+        $this->assertSame('123456789', $user->getId());
+        $this->assertSame('testuser', $user->getNickname());
+        $this->assertSame('Test User', $user->getName());
+        $this->assertSame('test@example.com', $user->getEmail());
+        $this->assertSame('https://example.com/avatar.jpg', $user->getAvatar());
+        $this->assertSame('fake-token', $user->token);
+        $this->assertSame('fake-refresh-token', $user->refreshToken);
+        $this->assertSame(3600, $user->expiresIn);
+        $this->assertSame([], $user->approvedScopes);
+        $this->assertSame('Test User', $user['name']);
+    }
+
+    public function test_it_can_create_a_fake_oauth2_user_with_attributes()
+    {
+        $user = OAuth2User::fake([
+            'id' => '987654321',
+            'nickname' => 'jane',
+            'name' => 'Jane Doe',
+            'email' => 'jane@example.com',
+            'avatar' => 'https://example.com/avatar.jpg',
+            'token' => 'custom-token',
+            'refreshToken' => 'custom-refresh-token',
+            'expiresIn' => 7200,
+            'approvedScopes' => ['read:user'],
+            'organization' => 'Laravel',
+        ]);
+
+        $this->assertSame('987654321', $user->getId());
+        $this->assertSame('jane', $user->getNickname());
+        $this->assertSame('Jane Doe', $user->getName());
+        $this->assertSame('jane@example.com', $user->getEmail());
+        $this->assertSame('https://example.com/avatar.jpg', $user->getAvatar());
+        $this->assertSame('custom-token', $user->token);
+        $this->assertSame('custom-refresh-token', $user->refreshToken);
+        $this->assertSame(7200, $user->expiresIn);
+        $this->assertSame(['read:user'], $user->approvedScopes);
+        $this->assertSame('Laravel', $user->organization);
+        $this->assertSame('Laravel', $user['organization']);
+    }
+
+    public function test_it_can_create_a_fake_oauth1_user()
+    {
+        $user = OAuth1User::fake();
+
+        $this->assertInstanceOf(OAuth1User::class, $user);
+        $this->assertSame('123456789', $user->getId());
+        $this->assertSame('testuser', $user->getNickname());
+        $this->assertSame('Test User', $user->getName());
+        $this->assertSame('test@example.com', $user->getEmail());
+        $this->assertSame('https://example.com/avatar.jpg', $user->getAvatar());
+        $this->assertSame('fake-token', $user->token);
+        $this->assertSame('fake-token-secret', $user->tokenSecret);
+        $this->assertSame('Test User', $user['name']);
+    }
+
+    public function test_it_can_create_a_fake_oauth1_user_with_attributes()
+    {
+        $user = OAuth1User::fake([
+            'id' => '987654321',
+            'nickname' => 'jane',
+            'name' => 'Jane Doe',
+            'email' => 'jane@example.com',
+            'avatar' => 'https://example.com/avatar.jpg',
+            'token' => 'custom-token',
+            'tokenSecret' => 'custom-token-secret',
+            'organization' => 'Laravel',
+        ]);
+
+        $this->assertSame('987654321', $user->getId());
+        $this->assertSame('jane', $user->getNickname());
+        $this->assertSame('Jane Doe', $user->getName());
+        $this->assertSame('jane@example.com', $user->getEmail());
+        $this->assertSame('https://example.com/avatar.jpg', $user->getAvatar());
+        $this->assertSame('custom-token', $user->token);
+        $this->assertSame('custom-token-secret', $user->tokenSecret);
+        $this->assertSame('Laravel', $user->organization);
+        $this->assertSame('Laravel', $user['organization']);
     }
 
     public function test_it_can_fake_a_driver_with_a_closure()


### PR DESCRIPTION
**Description**:

This PR adds a convenient way to create fake Socialite user instances when testing Socialite callbacks.

**Usage**:

Instead of manually mapping the expected user attributes, developers may now create fake OAuth users directly from the appropriate Socialite user classes themselves and save on having to define them all and instead override what they need overridden. For example:

Before:

```php
use Laravel\Socialite\Two\User;
use Laravel\Socialite\Socialite;

$attributes = [
    'id' => '123456789',
    'nickname' => 'testuser',
    'name' => 'Test User',
    'email' => 'test@example.com',
    'avatar' => 'https://example.com/avatar.jpg',
];

Socialite::fake('github', (new User)->setRaw($attributes)->map($attributes)
    ->setToken('fake-token')
    ->setRefreshToken('fake-refresh-token')
    ->setExpiresIn(3600)
    ->setApprovedScopes([]));
```

After:

```php
use Laravel\Socialite\Two\User;
use Laravel\Socialite\Socialite;

Socialite::fake('github', User::fake([
    'email' => 'test@example.com',
]));
```

OAuth 1 users may also be faked:

```php
use Laravel\Socialite\One\User;
use Laravel\Socialite\Socialite;

Socialite::fake('twitter', User::fake([
    'nickname' => 'testuser',
]));
```