### PR TITLE
Allow omitting redirect config key when using redirectUrl()

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -239,7 +239,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     public function buildProvider($provider, $config)
     {
-        $requiredKeys = ['client_id', 'client_secret', 'redirect'];
+        $requiredKeys = ['client_id', 'client_secret'];
 
         $missingKeys = array_diff($requiredKeys, array_keys($config ?? []));
 
@@ -277,7 +277,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function formatRedirectUrl(array $config)
     {
-        $redirect = value($config['redirect']);
+        $redirect = value($config['redirect'] ?? null);
 
         return Str::startsWith($redirect ?? '', '/')
                     ? $this->container->make('url')->to($redirect)

--- a/tests/SocialiteManagerTest.php
+++ b/tests/SocialiteManagerTest.php
@@ -109,11 +109,8 @@ class SocialiteManagerTest extends TestCase
         $factory->driver('github');
     }
 
-    public function test_it_throws_exception_when_redirect_is_missing()
+    public function test_it_can_instantiate_the_github_driver_without_redirect_in_config()
     {
-        $this->expectException(DriverMissingConfigurationException::class);
-        $this->expectExceptionMessage('Missing required configuration keys [redirect] for [Laravel\Socialite\Two\GithubProvider] OAuth provider.');
-
         $factory = $this->app->make(Factory::class);
 
         $this->app['config']->set('services.github', [
@@ -121,13 +118,15 @@ class SocialiteManagerTest extends TestCase
             'client_secret' => 'github-client-secret',
         ]);
 
-        $factory->driver('github');
+        $provider = $factory->driver('github')->redirectUrl('http://your-callback-url');
+
+        $this->assertInstanceOf(GithubProvider::class, $provider);
     }
 
     public function test_it_throws_exception_when_configuration_is_completely_missing()
     {
         $this->expectException(DriverMissingConfigurationException::class);
-        $this->expectExceptionMessage('Missing required configuration keys [client_id, client_secret, redirect] for [Laravel\Socialite\Two\GithubProvider] OAuth provider.');
+        $this->expectExceptionMessage('Missing required configuration keys [client_id, client_secret] for [Laravel\Socialite\Two\GithubProvider] OAuth provider.');
 
         $factory = $this->app->make(Factory::class);
 


### PR DESCRIPTION
When a developer calls `->redirectUrl('https://…')` directly on the driver, the `redirect` key in `config/services.php` is redundant — yet `buildProvider()` validated it as required and threw a `DriverMissingConfigurationException` before the provider was even constructed, making `redirectUrl()` impossible to use without a dummy `redirect` entry in config.

The fix removes `redirect` from `$requiredKeys` and adds a null-safe fallback in `formatRedirectUrl()` so the provider can be instantiated with an explicit URL set in code. The existing test asserting that a missing redirect throws was replaced with a test confirming `redirectUrl()` works without any `redirect` in config.

Closes #740.