### PR TITLE
Fix undefined array key error in LinkedIn provider

### DIFF
--- a/src/Two/LinkedInProvider.php
+++ b/src/Two/LinkedInProvider.php
@@ -108,15 +108,21 @@ class LinkedInProvider extends AbstractProvider implements ProviderInterface
 
         $images = (array) Arr::get($user, 'profilePicture.displayImage~.elements', []);
         $avatar = Arr::first($images, function ($image) {
+            $stillImage = $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage'] ?? [];
+
             return (
-                $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] ??
-                $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['displaySize']['width']
+                $stillImage['storageSize']['width'] ??
+                $stillImage['displaySize']['width'] ??
+                null
             ) === 100;
         });
         $originalAvatar = Arr::first($images, function ($image) {
+            $stillImage = $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage'] ?? [];
+
             return (
-                $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['storageSize']['width'] ??
-                $image['data']['com.linkedin.digitalmedia.mediaartifact.StillImage']['displaySize']['width']
+                $stillImage['storageSize']['width'] ??
+                $stillImage['displaySize']['width'] ??
+                null
             ) === 800;
         });
 

--- a/tests/LinkedInProviderTest.php
+++ b/tests/LinkedInProviderTest.php
@@ -77,4 +77,84 @@ class LinkedInProviderTest extends TestCase
         $this->assertSame($userId, $user->getId());
         $this->assertNull($user->getEmail());
     }
+
+    public function test_it_can_map_a_user_when_the_still_image_key_is_missing()
+    {
+        $request = m::mock(Request::class);
+        $request->allows('input')->with('code')->andReturns('fake-code');
+
+        $stream = m::mock(StreamInterface::class);
+        $stream->allows('__toString')->andReturns(json_encode(['access_token' => 'fake-token']));
+
+        $accessTokenResponse = m::mock(ResponseInterface::class);
+        $accessTokenResponse->allows('getBody')->andReturns($stream);
+
+        $basicProfileStream = m::mock(StreamInterface::class);
+        $basicProfileStream->allows('__toString')->andReturns(json_encode([
+            'id' => $userId = 1,
+            'profilePicture' => [
+                'displayImage~' => [
+                    'elements' => [
+                        [
+                            'identifiers' => [
+                                ['identifier' => 'https://media.licdn.com/avatar.jpg'],
+                            ],
+                            'data' => [],
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+
+        $basicProfileResponse = m::mock(ResponseInterface::class);
+        $basicProfileResponse->allows('getBody')->andReturns($basicProfileStream);
+
+        $emailAddressStream = m::mock(StreamInterface::class);
+        $emailAddressStream->allows('__toString')->andReturns(json_encode(['elements' => []]));
+
+        $emailAddressResponse = m::mock(ResponseInterface::class);
+        $emailAddressResponse->allows('getBody')->andReturns($emailAddressStream);
+
+        $guzzle = m::mock(Client::class);
+        $guzzle->expects('post')->andReturns($accessTokenResponse);
+        $guzzle->allows('get')->with('https://api.linkedin.com/v2/me', [
+            RequestOptions::HEADERS => [
+                'Authorization' => 'Bearer fake-token',
+                'X-RestLi-Protocol-Version' => '2.0.0',
+            ],
+            RequestOptions::QUERY => [
+                'projection' => '(id,firstName,lastName,profilePicture(displayImage~:playableStreams),vanityName)',
+            ],
+        ])->andReturns($basicProfileResponse);
+        $guzzle->allows('get')->with('https://api.linkedin.com/v2/emailAddress', [
+            RequestOptions::HEADERS => [
+                'Authorization' => 'Bearer fake-token',
+                'X-RestLi-Protocol-Version' => '2.0.0',
+            ],
+            RequestOptions::QUERY => [
+                'q' => 'members',
+                'projection' => '(elements*(handle~))',
+            ],
+        ])->andReturns($emailAddressResponse);
+
+        $provider = new LinkedInProvider($request, 'client_id', 'client_secret', 'redirect');
+        $provider->stateless();
+        $provider->setHttpClient($guzzle);
+
+        // LinkedIn omits the StillImage key for some accounts, and Laravel turns
+        // the resulting "Undefined array key" warning into an exception.
+        set_error_handler(function ($severity, $message, $file, $line) {
+            throw new \ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            $user = $provider->user();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertSame($userId, $user->getId());
+        $this->assertNull($user->getAvatar());
+    }
 }


### PR DESCRIPTION
When LinkedIn returns a profile picture without the `StillImage` key, the fallback read on the right side of the `??` still accesses that missing key and throws an `Undefined array key` error while mapping the user. This pulls the still image into a local variable first so both the storage and display size lookups coalesce safely.

Fixes #783.
