### PR TITLE
Fix return type of the Socialite facade's driver method

### DIFF
--- a/src/Socialite.php
+++ b/src/Socialite.php
@@ -7,7 +7,7 @@ use Laravel\Socialite\Contracts\Factory;
 use Laravel\Socialite\Testing\SocialiteFake;
 
 /**
- * @method static \Laravel\Socialite\Contracts\Provider driver(string $driver = null)
+ * @method static \Laravel\Socialite\Two\AbstractProvider driver(string $driver = null)
  * @method static \Laravel\Socialite\Two\AbstractProvider buildProvider(string $provider, array $config)
  * @method static \Laravel\Socialite\SocialiteManager extend(string $driver, \Closure $callback)
  * @method array getScopes()


### PR DESCRIPTION
`Socialite::driver('...')` is typed to return `Contracts\Provider`, which only declares `redirect()` and `user()`, so IDEs flag `->scopes()` and the other fluent methods as undefined. The built-in OAuth2 drivers return `Two\AbstractProvider` (already used for `buildProvider()` just below it), so annotating `driver()` with that clears the warning.

Fixes #784
