### PR TITLE
Make the `redirect` config key optional

### DIFF
--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -239,7 +239,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     public function buildProvider($provider, $config)
     {
-        $requiredKeys = ['client_id', 'client_secret', 'redirect'];
+        $requiredKeys = ['client_id', 'client_secret'];
 
         $missingKeys = array_diff($requiredKeys, array_keys($config ?? []));
 
@@ -277,7 +277,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
      */
     protected function formatRedirectUrl(array $config)
     {
-        $redirect = value($config['redirect']);
+        $redirect = value($config['redirect'] ?? null);
 
         return Str::startsWith($redirect ?? '', '/')
                     ? $this->container->make('url')->to($redirect)

--- a/tests/SocialiteManagerTest.php
+++ b/tests/SocialiteManagerTest.php
@@ -109,11 +109,8 @@ class SocialiteManagerTest extends TestCase
         $factory->driver('github');
     }
 
-    public function test_it_throws_exception_when_redirect_is_missing()
+    public function test_it_can_instantiate_the_driver_without_redirect_configuration()
     {
-        $this->expectException(DriverMissingConfigurationException::class);
-        $this->expectExceptionMessage('Missing required configuration keys [redirect] for [Laravel\Socialite\Two\GithubProvider] OAuth provider.');
-
         $factory = $this->app->make(Factory::class);
 
         $this->app['config']->set('services.github', [
@@ -121,13 +118,17 @@ class SocialiteManagerTest extends TestCase
             'client_secret' => 'github-client-secret',
         ]);
 
-        $factory->driver('github');
+        // The redirect can be provided at runtime via redirectUrl(), so it is no
+        // longer a required configuration key.
+        $provider = $factory->driver('github')->redirectUrl('https://example.com/callback');
+
+        $this->assertInstanceOf(\Laravel\Socialite\Two\GithubProvider::class, $provider);
     }
 
     public function test_it_throws_exception_when_configuration_is_completely_missing()
     {
         $this->expectException(DriverMissingConfigurationException::class);
-        $this->expectExceptionMessage('Missing required configuration keys [client_id, client_secret, redirect] for [Laravel\Socialite\Two\GithubProvider] OAuth provider.');
+        $this->expectExceptionMessage('Missing required configuration keys [client_id, client_secret] for [Laravel\Socialite\Two\GithubProvider] OAuth provider.');
 
         $factory = $this->app->make(Factory::class);
 


### PR DESCRIPTION
Closes #740.

### Problem

The redirect URL can be set at runtime with `->redirectUrl($url)`, but `SocialiteManager::buildProvider()` still lists `redirect` as a **required** config key. So even when you only ever set the redirect programmatically, you have to add a placeholder `redirect` (e.g. an empty string) to `config/services.php`, or you get a `DriverMissingConfigurationException`.

### Change

- Drop `redirect` from `$requiredKeys` in `buildProvider()` (only `client_id` and `client_secret` remain required).
- Make `formatRedirectUrl()` tolerate a missing `redirect` key (`$config['redirect'] ?? null`).

You can now do:

```php
// config/services.php — no redirect key needed
'github' => [
    'client_id'     => env('GITHUB_CLIENT_ID'),
    'client_secret' => env('GITHUB_CLIENT_SECRET'),
],
```
```php
Socialite::driver('github')->redirectUrl($url)->redirect();
```

### Note on behavior change

This relaxes a previously-required (and tested) key, so I updated `SocialiteManagerTest`:

- `test_it_throws_exception_when_redirect_is_missing` → `test_it_can_instantiate_the_driver_without_redirect_configuration` (now asserts the provider builds).
- `test_it_throws_exception_when_configuration_is_completely_missing` — expected missing-keys message updated to `[client_id, client_secret]`.

Full suite passes (48 tests). Happy to adjust if you'd prefer to keep `redirect` required — this follows the `help wanted` label and the request in #740.
