### PR TITLE
fix: Validate Facebook OIDC token nonce

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -262,7 +262,7 @@ abstract class AbstractProvider implements ProviderContract
     }
 
     /**
-     * Get a Social User instance from a known access token.
+     * Get a Socialite user instance from a known access token.
      *
      * @param  string  $token
      * @return \Laravel\Socialite\Two\User

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -62,7 +62,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     protected $lastToken;
 
     /**
-     * The nonce expected in Facebook Limited Login OIDC tokens.
+     * The nonce expected when using Facebook Limited Login OIDC tokens.
      *
      * @var string|null
      */
@@ -110,6 +110,22 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     }
 
     /**
+     * Get a Socialite user instance from a known access token.
+     *
+     * @param  string  $token
+     * @param  string|null  $nonce
+     * @return \Laravel\Socialite\Two\User
+     */
+    public function userFromToken($token, $nonce = null)
+    {
+        if ($nonce !== null) {
+            $this->withNonce($nonce);
+        }
+
+        return parent::userFromToken($token);
+    }
+
+    /**
      * Get user based on the OIDC token.
      *
      * @param  string  $token
@@ -148,16 +164,6 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
         }
 
         return $data;
-    }
-
-    /**
-     * Get the expected OIDC token nonce.
-     *
-     * @return string|null
-     */
-    protected function getExpectedNonce()
-    {
-        return $this->expectedNonce ?? Arr::get($this->parameters, 'nonce');
     }
 
     /**
@@ -289,23 +295,7 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     }
 
     /**
-     * Get a Social User instance from a known access token.
-     *
-     * @param  string  $token
-     * @param  string|null  $nonce
-     * @return \Laravel\Socialite\Two\User
-     */
-    public function userFromToken($token, $nonce = null)
-    {
-        if ($nonce !== null) {
-            $this->withNonce($nonce);
-        }
-
-        return parent::userFromToken($token);
-    }
-
-    /**
-     * Specify the nonce expected in Facebook Limited Login OIDC tokens.
+     * Specify the nonce expected when using Facebook Limited Login OIDC tokens.
      *
      * @param  string  $nonce
      * @return $this
@@ -315,6 +305,16 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
         $this->expectedNonce = $nonce;
 
         return $this;
+    }
+
+    /**
+     * Get the expected OIDC token nonce.
+     *
+     * @return string|null
+     */
+    protected function getExpectedNonce()
+    {
+        return $this->expectedNonce ?? Arr::get($this->parameters, 'nonce');
     }
 
     /**

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -62,6 +62,13 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     protected $lastToken;
 
     /**
+     * The nonce expected in Facebook Limited Login OIDC tokens.
+     *
+     * @var string|null
+     */
+    protected $expectedNonce;
+
+    /**
      * {@inheritdoc}
      */
     protected function getAuthUrl($state)
@@ -121,6 +128,15 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
         throw_if($data['aud'] !== $this->clientId, new Exception('Token has incorrect audience.'));
         throw_if($data['iss'] !== 'https://www.facebook.com', new Exception('Token has incorrect issuer.'));
 
+        $expectedNonce = $this->getExpectedNonce();
+
+        throw_if(
+            $expectedNonce === null ||
+            ! isset($data['nonce']) ||
+            ! hash_equals($expectedNonce, (string) $data['nonce']),
+            new Exception('Token has incorrect nonce.')
+        );
+
         $data['id'] = $data['sub'];
 
         if (isset($data['given_name'])) {
@@ -132,6 +148,16 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
         }
 
         return $data;
+    }
+
+    /**
+     * Get the expected OIDC token nonce.
+     *
+     * @return string|null
+     */
+    protected function getExpectedNonce()
+    {
+        return $this->expectedNonce ?? Arr::get($this->parameters, 'nonce');
     }
 
     /**
@@ -260,6 +286,35 @@ class FacebookProvider extends AbstractProvider implements ProviderInterface
     public function lastToken()
     {
         return $this->lastToken;
+    }
+
+    /**
+     * Get a Social User instance from a known access token.
+     *
+     * @param  string  $token
+     * @param  string|null  $nonce
+     * @return \Laravel\Socialite\Two\User
+     */
+    public function userFromToken($token, $nonce = null)
+    {
+        if ($nonce !== null) {
+            $this->withNonce($nonce);
+        }
+
+        return parent::userFromToken($token);
+    }
+
+    /**
+     * Specify the nonce expected in Facebook Limited Login OIDC tokens.
+     *
+     * @param  string  $nonce
+     * @return $this
+     */
+    public function withNonce($nonce)
+    {
+        $this->expectedNonce = $nonce;
+
+        return $this;
     }
 
     /**

--- a/tests/FacebookProviderOIDCTokenTest.php
+++ b/tests/FacebookProviderOIDCTokenTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Laravel\Socialite\Tests;
+
+use Exception;
+use Firebase\JWT\JWT;
+use Illuminate\Http\Request;
+use Laravel\Socialite\Tests\Fixtures\FacebookOIDCTestProviderStub;
+use Laravel\Socialite\Two\User;
+use PHPUnit\Framework\TestCase;
+
+class FacebookProviderOIDCTokenTest extends TestCase
+{
+    public function test_it_validates_expected_nonce_for_facebook_oidc_tokens()
+    {
+        $provider = $this->getProvider();
+
+        $user = $provider->userFromToken(
+            $this->createOidcToken(['nonce' => 'expected-nonce']),
+            'expected-nonce'
+        );
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertSame('123456789', $user->getId());
+        $this->assertSame('Taylor Otwell', $user->getName());
+        $this->assertSame('taylor@example.com', $user->getEmail());
+    }
+
+    public function test_it_validates_expected_nonce_from_custom_parameters()
+    {
+        $provider = $this->getProvider();
+
+        $user = $provider
+            ->with(['nonce' => 'expected-nonce'])
+            ->userFromToken($this->createOidcToken(['nonce' => 'expected-nonce']));
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertSame('123456789', $user->getId());
+    }
+
+    public function test_it_rejects_facebook_oidc_tokens_with_an_incorrect_nonce()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Token has incorrect nonce.');
+
+        $provider = $this->getProvider();
+
+        $provider->userFromToken(
+            $this->createOidcToken(['nonce' => 'unexpected-nonce']),
+            'expected-nonce'
+        );
+    }
+
+    public function test_it_rejects_facebook_oidc_tokens_without_an_expected_nonce()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Token has incorrect nonce.');
+
+        $provider = $this->getProvider();
+
+        $provider->userFromToken($this->createOidcToken(['nonce' => 'expected-nonce']));
+    }
+
+    public function test_it_rejects_facebook_oidc_tokens_without_a_nonce_when_one_is_expected()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Token has incorrect nonce.');
+
+        $provider = $this->getProvider();
+
+        $provider->userFromToken(
+            $this->createOidcToken(['nonce' => null]),
+            'expected-nonce'
+        );
+    }
+
+    protected function getProvider()
+    {
+        return new FacebookOIDCTestProviderStub(
+            Request::create('/'),
+            'client_id',
+            'client_secret',
+            'http://localhost/callback'
+        );
+    }
+
+    protected function createOidcToken(array $overrides = [])
+    {
+        $payload = array_merge([
+            'iss' => 'https://www.facebook.com',
+            'sub' => '123456789',
+            'aud' => 'client_id',
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@example.com',
+            'iat' => time(),
+            'exp' => time() + 3600,
+        ], $overrides);
+
+        $payload = array_filter($payload, function ($value) {
+            return $value !== null;
+        });
+
+        return JWT::encode($payload, FacebookOIDCTestProviderStub::TEST_SECRET, 'HS256', 'test-key-id');
+    }
+}

--- a/tests/Fixtures/FacebookOIDCTestProviderStub.php
+++ b/tests/Fixtures/FacebookOIDCTestProviderStub.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Laravel\Socialite\Tests\Fixtures;
+
+use Firebase\JWT\Key;
+use Laravel\Socialite\Two\FacebookProvider;
+
+class FacebookOIDCTestProviderStub extends FacebookProvider
+{
+    public const TEST_SECRET = 'abcdefghijklmnopqrstuvwxyz123456';
+
+    /**
+     * Get the public key to verify the signature of OIDC token.
+     *
+     * @param  string  $kid
+     * @return \Firebase\JWT\Key
+     */
+    protected function getPublicKeyOfOIDCToken(string $kid)
+    {
+        return new Key(self::TEST_SECRET, 'HS256');
+    }
+}


### PR DESCRIPTION
<!--
We are not accepting new adapters.

Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

- I added nonce validation because token was not properly checked
- I sent a message for Taylor a month ago but I couldn't get any reply. so here it is