### PR TITLE
Upgrade phpseclib to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,11 +28,7 @@ jobs:
             laravel: 9
           - php: 8.1
             laravel: 9
-          - php: '8.0'
-            laravel: 9
           - php: 8.1
-            laravel: 8
-          - php: '8.0'
             laravel: 8
           - php: '8.3'
             laravel: '13'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/laravel/socialite/compare/v5.30.0...5.x)
 
+* Require PHP 8.1 and phpseclib 4.0.
+
 ## [v5.30.0](https://github.com/laravel/socialite/compare/v5.29.0...v5.30.0) - 2026-08-13
 
 * Bump actions/checkout from 7.0.0 to 7.0.1 in the github-actions group by [@dependabot](https://github.com/dependabot)[bot] in https://github.com/laravel/socialite/pull/788

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade Guide
 
+## Upgrading To 6.0 From 5.x
+
+### Minimum PHP Version
+
+PHP 8.1 is now the minimum required version.
+
+### phpseclib Version
+
+phpseclib 4.0 is now required. If your application uses phpseclib directly, review its [changelog](https://github.com/phpseclib/phpseclib/blob/master/CHANGELOG.md) for the namespace changes from `phpseclib3` to `phpseclib4`.
+
 ## Upgrading To 5.0 From 4.x
 
 ### Minimum PHP Version

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "firebase/php-jwt": "^6.4|^7.0",
         "guzzlehttp/guzzle": "^6.0|^7.0",
@@ -26,7 +26,7 @@
         "illuminate/http": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "league/oauth1-client": "^1.11",
-        "phpseclib/phpseclib": "^3.0"
+        "phpseclib/phpseclib": "^4.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -7,8 +7,8 @@ use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
-use phpseclib3\Crypt\RSA;
-use phpseclib3\Math\BigInteger;
+use phpseclib4\Crypt\RSA;
+use phpseclib4\Math\BigInteger;
 
 class FacebookProvider extends AbstractProvider implements ProviderInterface
 {


### PR DESCRIPTION
## Summary

- Raise the minimum supported PHP version to 8.1.
- Upgrade `phpseclib/phpseclib` from 3.x to 4.0.
- Update the Facebook OIDC RSA key imports to the `phpseclib4` namespace.
- Remove PHP 8.0 entries from the CI matrix.
- Document the PHP and phpseclib requirements for the next major release.

## Validation

- `composer validate --strict`
- `composer check-platform-reqs --no-interaction`
- `vendor/bin/phpunit` (53 tests, 186 assertions passed)
- `php -d memory_limit=512M vendor/bin/phpstan analyse --no-progress --memory-limit=512M` (no errors)

PHPUnit reports one existing deprecation.
